### PR TITLE
misc: use KotlinxCoroutines* 1.7.x internally

### DIFF
--- a/brazil/transforms.json
+++ b/brazil/transforms.json
@@ -14,9 +14,9 @@
     "org.jetbrains.kotlin:kotlin-stdlib:1.8.10": "KotlinStdlib-1.8.x",
     "org.jetbrains.kotlinx:atomicfu-jvm:0.19.0": "AtomicfuJvm-0.19.0",
     "org.jetbrains.kotlinx:atomicfu:0.19.0": "Atomicfu-0.19.0",
-    "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4": "KotlinxCoroutinesCoreJvm-1.6.x",
-    "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4": "KotlinxCoroutinesCore-1.6.x",
-    "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4": "KotlinxCoroutinesJdk8-1.6.x",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4": "KotlinxCoroutinesCoreJvm-1.7.x",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4": "KotlinxCoroutinesCore-1.7.x",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4": "KotlinxCoroutinesJdk8-1.7.x",
     "org.slf4j:slf4j-api:2.0.6": "Maven-org-slf4j_slf4j-api-2.x",
     "software.amazon.awssdk.crt:aws-crt:0.21.7": "Aws-crt-java-1.0.x"
   },


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Bump to using KotlinxCoroutines 1.7.x internally to resolve major version conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
