### PR TITLE
fix: extra throws exception instead of returning null

### DIFF
--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ProjectExt.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ProjectExt.kt
@@ -57,7 +57,7 @@ public fun Project.localProperties(): Map<String, Any> {
  * @return property if it exists or null
  */
 public fun Project.prop(name: String): Any? =
-    properties[name] ?: localProperties()[name] ?: extra[name]
+    properties[name] ?: localProperties()[name] ?: extra.getOrNull(name)
 
 inline fun <reified T> Project.typedProp(name: String): T? {
     val any = prop(name)


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Fixes exception when property doesn't exist in any of the property containers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
