### PR TITLE
configure ktlint with custom rules

### DIFF
--- a/build-plugins/build.gradle.kts
+++ b/build-plugins/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
     implementation(kotlin("gradle-plugin", "1.8.22"))
+    runtimeOnly(project(":ktlint-rules"))
 }
 
 group = "aws.sdk.kotlin"

--- a/build-plugins/build.gradle.kts
+++ b/build-plugins/build.gradle.kts
@@ -23,20 +23,10 @@ repositories {
 dependencies {
     implementation(gradleApi())
     implementation(kotlin("gradle-plugin", "1.8.22"))
+    runtimeOnly(project(":ktlint-rules"))
 }
 
 group = "aws.sdk.kotlin"
-
-val ktlint = configurations.create("ktlint") {
-    attributes {
-        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
-    }
-}
-
-dependencies {
-    ktlint(libs.ktlint)
-    ktlint(project(":ktlint-rules"))
-}
 
 gradlePlugin {
     plugins {

--- a/build-plugins/build.gradle.kts
+++ b/build-plugins/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 dependencies {
     implementation(gradleApi())
     implementation(kotlin("gradle-plugin", "1.8.22"))
+    // make our custom lint rules available to the buildscript classpath
     runtimeOnly(project(":ktlint-rules"))
 }
 
@@ -34,11 +35,6 @@ gradlePlugin {
             id = "aws.sdk.kotlin.kmp"
             implementationClass = "aws.sdk.kotlin.gradle.kmp.KmpDefaultsPlugin"
         }
-
-        // create("buildDefaultsPlugin") {
-        //     id = "aws.sdk.kotlin.build-defaults"
-        //     implementationClass = "aws.sdk.kotlin.gradle.BuildDefaultsPlugin"
-        // }
     }
 }
 

--- a/build-plugins/build.gradle.kts
+++ b/build-plugins/build.gradle.kts
@@ -23,10 +23,20 @@ repositories {
 dependencies {
     implementation(gradleApi())
     implementation(kotlin("gradle-plugin", "1.8.22"))
-    runtimeOnly(project(":ktlint-rules"))
 }
 
 group = "aws.sdk.kotlin"
+
+val ktlint = configurations.create("ktlint") {
+    attributes {
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+    }
+}
+
+dependencies {
+    ktlint(libs.ktlint)
+    ktlint(project(":ktlint-rules"))
+}
 
 gradlePlugin {
     plugins {

--- a/build-plugins/build.gradle.kts
+++ b/build-plugins/build.gradle.kts
@@ -33,6 +33,11 @@ gradlePlugin {
             id = "aws.sdk.kotlin.kmp"
             implementationClass = "aws.sdk.kotlin.gradle.kmp.KmpDefaultsPlugin"
         }
+
+        // create("buildDefaultsPlugin") {
+        //     id = "aws.sdk.kotlin.build-defaults"
+        //     implementationClass = "aws.sdk.kotlin.gradle.BuildDefaultsPlugin"
+        // }
     }
 }
 

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -17,7 +17,7 @@ import org.gradle.kotlin.dsl.register
  * @param lintPaths list of paths relative to the project root to lint (or not lint).
  */
 fun Project.configureLinting(lintPaths: List<String>) {
-    verifyRootProject { "AWS SDK lint configuration is expected to be configured on the root project" }
+    verifyRootProject { "Kotlin SDK lint configuration is expected to be configured on the root project" }
 
     val ktlint = configurations.create("ktlint") {
         attributes {

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -19,19 +19,19 @@ import org.gradle.kotlin.dsl.register
 fun Project.configureLinting(lintPaths: List<String>) {
     verifyRootProject { "AWS SDK lint configuration is expected to be configured on the root project" }
 
-    // val ktlint = configurations.create("ktlint") {
-    //     attributes {
-    //         attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
-    //     }
-    // }
-    //
-    // // TODO - is there anyway to align this with the version from libs.versions.toml in this project/repo
-    // val ktlintVersion = "0.48.1"
-    // dependencies {
-    //     ktlint("com.pinterest:ktlint:$ktlintVersion")
-    //     // this is expected available (usually by configuring sourceControl and telling gradle it's produced by this repo)
-    //     ktlint("aws.sdk.kotlin:ktlint-rules")
-    // }
+    val ktlint = configurations.create("ktlint") {
+        attributes {
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+        }
+    }
+
+    // TODO - is there anyway to align this with the version from libs.versions.toml in this project/repo
+    val ktlintVersion = "0.48.1"
+    dependencies {
+        ktlint("com.pinterest:ktlint:$ktlintVersion")
+        // this is expected available (usually by configuring sourceControl and telling gradle it's produced by this repo)
+        // ktlint("aws.sdk.kotlin:ktlint-rules")
+    }
 
     tasks.register<JavaExec>("ktlint") {
         description = "Check Kotlin code style."

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -33,10 +33,12 @@ fun Project.configureLinting(lintPaths: List<String>) {
         // ktlint("aws.sdk.kotlin:ktlint-rules")
     }
 
+    // add the buildscript classpath which should pickup our custom ktlint-rules + any custom rules added by consumer
+    val execKtlintClaspath= ktlint + buildscript.configurations.getByName("classpath")
     tasks.register<JavaExec>("ktlint") {
         description = "Check Kotlin code style."
         group = "Verification"
-        classpath = configurations.getByName("ktlint")
+        classpath = execKtlintClaspath
         mainClass.set("com.pinterest.ktlint.Main")
         args = lintPaths
         jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
@@ -45,7 +47,7 @@ fun Project.configureLinting(lintPaths: List<String>) {
     tasks.register<JavaExec>("ktlintFormat") {
         description = "Auto fix Kotlin code style violations"
         group = "formatting"
-        classpath = configurations.getByName("ktlint")
+        classpath = execKtlintClaspath
         mainClass.set("com.pinterest.ktlint.Main")
         args = listOf("-F") + lintPaths
         jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -30,7 +30,7 @@ fun Project.configureLinting(lintPaths: List<String>) {
     dependencies {
         ktlint("com.pinterest:ktlint:$ktlintVersion")
         // this is expected available (usually by configuring sourceControl and telling gradle it's produced by this repo)
-        ktlint(project(":aws-kotlin-repo-tools:ktlint-rules"))
+        ktlint("aws.sdk.kotlin:ktlint-rules")
     }
 
     tasks.register<JavaExec>("ktlint") {

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -29,12 +29,11 @@ fun Project.configureLinting(lintPaths: List<String>) {
     val ktlintVersion = "0.48.1"
     dependencies {
         ktlint("com.pinterest:ktlint:$ktlintVersion")
-        // this is expected available (usually by configuring sourceControl and telling gradle it's produced by this repo)
-        // ktlint("aws.sdk.kotlin:ktlint-rules")
     }
 
-    // add the buildscript classpath which should pickup our custom ktlint-rules + any custom rules added by consumer
-    val execKtlintClaspath= ktlint + buildscript.configurations.getByName("classpath")
+    // add the buildscript classpath which should pickup our custom ktlint-rules (via runtimeOnly dep on this plugin)
+    // plus any custom rules added by consumer
+    val execKtlintClaspath = ktlint + buildscript.configurations.getByName("classpath")
     tasks.register<JavaExec>("ktlint") {
         description = "Check Kotlin code style."
         group = "Verification"

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -19,19 +19,19 @@ import org.gradle.kotlin.dsl.register
 fun Project.configureLinting(lintPaths: List<String>) {
     verifyRootProject { "AWS SDK lint configuration is expected to be configured on the root project" }
 
-    val ktlint = configurations.create("ktlint") {
-        attributes {
-            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
-        }
-    }
-
-    // TODO - is there anyway to align this with the version from libs.versions.toml in this project/repo
-    val ktlintVersion = "0.48.1"
-    dependencies {
-        ktlint("com.pinterest:ktlint:$ktlintVersion")
-        // this is expected available (usually by configuring sourceControl and telling gradle it's produced by this repo)
-        ktlint("aws.sdk.kotlin:ktlint-rules")
-    }
+    // val ktlint = configurations.create("ktlint") {
+    //     attributes {
+    //         attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+    //     }
+    // }
+    //
+    // // TODO - is there anyway to align this with the version from libs.versions.toml in this project/repo
+    // val ktlintVersion = "0.48.1"
+    // dependencies {
+    //     ktlint("com.pinterest:ktlint:$ktlintVersion")
+    //     // this is expected available (usually by configuring sourceControl and telling gradle it's produced by this repo)
+    //     ktlint("aws.sdk.kotlin:ktlint-rules")
+    // }
 
     tasks.register<JavaExec>("ktlint") {
         description = "Check Kotlin code style."

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -30,7 +30,7 @@ fun Project.configureLinting(lintPaths: List<String>) {
     dependencies {
         ktlint("com.pinterest:ktlint:$ktlintVersion")
         // this is expected available (usually by configuring sourceControl and telling gradle it's produced by this repo)
-        ktlint("aws.sdk.kotlin:ktlint-rules")
+        ktlint(project(":aws-kotlin-repo-tools:ktlint-rules"))
     }
 
     tasks.register<JavaExec>("ktlint") {

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/LintRules.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/LintRules.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.dsl
+
+import aws.sdk.kotlin.gradle.util.verifyRootProject
+import org.gradle.api.Project
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.tasks.JavaExec
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Configure lint rules for the project
+ * @param lintPaths list of paths relative to the project root to lint (or not lint).
+ */
+fun Project.configureLinting(lintPaths: List<String>) {
+    verifyRootProject { "AWS SDK lint configuration is expected to be configured on the root project" }
+
+    val ktlint = configurations.create("ktlint") {
+        attributes {
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+        }
+    }
+
+    // TODO - is there anyway to align this with the version from libs.versions.toml in this project/repo
+    val ktlintVersion = "0.48.1"
+    dependencies {
+        ktlint("com.pinterest:ktlint:$ktlintVersion")
+        // this is expected available (usually by configuring sourceControl and telling gradle it's produced by this repo)
+        ktlint("aws.sdk.kotlin:ktlint-rules")
+    }
+
+    tasks.register<JavaExec>("ktlint") {
+        description = "Check Kotlin code style."
+        group = "Verification"
+        classpath = configurations.getByName("ktlint")
+        mainClass.set("com.pinterest.ktlint.Main")
+        args = lintPaths
+        jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+    }
+
+    tasks.register<JavaExec>("ktlintFormat") {
+        description = "Auto fix Kotlin code style violations"
+        group = "formatting"
+        classpath = configurations.getByName("ktlint")
+        mainClass.set("com.pinterest.ktlint.Main")
+        args = listOf("-F") + lintPaths
+        jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+    }
+}

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/KmpDefaultsPlugin.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/KmpDefaultsPlugin.kt
@@ -4,6 +4,7 @@
  */
 package aws.sdk.kotlin.gradle.kmp
 
+import aws.sdk.kotlin.gradle.util.verifyRootProject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -15,7 +16,10 @@ import org.gradle.api.Project
  */
 class KmpDefaultsPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.logger.info("applying kmp defaults plugin to $target")
-        target.configureKmpTargets()
+        with(target) {
+            logger.info("applying kmp defaults plugin to $target")
+            verifyRootProject { "AWS SDK KmpDefaultsPlugin requires installation into root project" }
+            configureKmpTargets()
+        }
     }
 }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/KmpProjectExt.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/KmpProjectExt.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.kmp
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.the
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/**
+ * Allows configuration from parent projects subprojects/allprojects block when they haven't configured the KMP
+ * plugin but the subproject has applied it. The extension is otherwise not visible.
+ */
+fun Project.kotlin(block: KotlinMultiplatformExtension.() -> Unit) {
+    configure(block)
+}
+val Project.kotlin: KotlinMultiplatformExtension get() = the()

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/util/ProjectExt.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/util/ProjectExt.kt
@@ -2,25 +2,14 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package aws.sdk.kotlin.gradle.kmp
+package aws.sdk.kotlin.gradle.util
 
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtraPropertiesExtension
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.extra
-import org.gradle.kotlin.dsl.the
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import java.io.File
 import java.util.*
-
-/**
- * Allows configuration from parent projects subprojects/allprojects block when they haven't configured the KMP
- * plugin but the subproject has applied it. The extension is otherwise not visible.
- */
-fun Project.kotlin(block: KotlinMultiplatformExtension.() -> Unit) {
-    configure(block)
-}
-val Project.kotlin: KotlinMultiplatformExtension get() = the()
 
 public fun <T> ExtraPropertiesExtension.getOrNull(name: String): T? {
     if (!has(name)) return null
@@ -68,3 +57,12 @@ inline fun <reified T> Project.typedProp(name: String): T? {
         else -> error("unknown type ${T::class} for property $name")
     }
 }
+
+public inline fun Project.verifyRootProject(lazyMessage: () -> Any) {
+    if (rootProject != this) {
+        val message = lazyMessage()
+        throw AwsSdkGradleException(message.toString())
+    }
+}
+
+class AwsSdkGradleException(message: String) : GradleException(message)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 allprojects {
+    group = "aws.sdk.kotlin"
+
     repositories {
         mavenCentral()
     }

--- a/ktlint-rules/build.gradle.kts
+++ b/ktlint-rules/build.gradle.kts
@@ -2,6 +2,12 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 description = "Lint rules for the AWS SDK for Kotlin"
 
@@ -11,16 +17,27 @@ plugins {
 
 kotlin {
     sourceSets {
-        val main by getting {
+        main {
             dependencies {
                 implementation(libs.ktlint.core)
             }
         }
 
-        val test by getting {
+        test {
             dependencies {
                 implementation(libs.ktlint.test)
             }
         }
     }
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
 }


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Create the `ktlint` and `ktlintFormat` tasks and include our custom `ktlint-rules` by default. This works by adding our custom lint rules project as a runtime dependency of the plugin. The buildscript classpath is then included as the classpath for the ktlint exec task. This allows dowstream projects to define additional project specific rules should the need arise by simpling adding them to the buildscript classpath

e.g.

```kotlin
buildscript {
    classpath("aws.sdk.kotlin:build-plugins")   // includes ktlint-rules
    classpath(project(":my-custom-rules"))
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
