### PR TITLE
re-usable composite action to pull dependency versions

### DIFF
--- a/.github/actions/checkout-head/action.yml
+++ b/.github/actions/checkout-head/action.yml
@@ -40,16 +40,17 @@ runs:
         fi
         
         if git ls-remote --exit-code --heads "https://github.com/$REPOSITORY.git" "$ref"; then
-          echo "::notice ::Checkout Head: using $ref for $REPOSITORY"
+          echo "::notice ::Checkout Head: using '$ref' for $REPOSITORY"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
         else
           baseref="main"
           if [ -n "$GITHUB_BASE_REF" ]; then
+            echo "attempting GH base ref: $GITHUB_BASE_REF"
             if git ls-remote --exit-code --heads "https://github.com/$REPOSITORY.git" "$GITHUB_BASE_REF"; then
               baseref="$GITHUB_BASE_REF"
             fi
           fi
-          echo "::notice ::Checkout Head: $REPOSITORY does not have the head ref $ref, using base $baseref"
+          echo "::notice ::Checkout Head: $REPOSITORY does not have the head ref '$ref', using base '$baseref'"
           echo "ref=$baseref" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/actions/checkout-head/action.yml
+++ b/.github/actions/checkout-head/action.yml
@@ -1,0 +1,62 @@
+name: Checkout Head
+description: >
+  Attempt to checkout a repository using the head ref. If it doesn't exist attempt to fallback to the 
+  base ref. If it doesn't exist then use the default branch.
+
+inputs:
+  fetch-depth:
+    description: 'Number of commits to fetch. 0 indicates all history for all branches and tags.'
+    default: 1
+    required: false
+  path:
+    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+    default: ''
+    required: false
+  repository:
+    description: 'Repository name with owner. For example, actions/checkout'
+    default: ${{ github.repository }}
+    required: false
+  token:
+    description: >
+      Personal access token (PAT) used to fetch the repository. The PAT is configured
+      with the local git config, which enables your scripts to run authenticated git
+      commands. The post-job step removes the PAT.
+    default: ${{ github.token }}
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - id: repo
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPOSITORY: ${{ inputs.repository }}
+      run: |
+        ref="$GITHUB_REF"
+        if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          ref="$GITHUB_HEAD_REF"
+        fi
+        
+        if git ls-remote --exit-code --heads "https://github.com/$REPOSITORY.git" "$ref"; then
+          echo "::notice::Checkout: using $ref for $REPOSITORY"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+        else
+          baseref="main"
+          if [ -n "$GITHUB_BASE_REF" ]; then
+            if git ls-remote --exit-code --heads "https://github.com/$REPOSITORY.git" "$GITHUB_BASE_REF"; then
+              baseref="$GITHUB_BASE_REF"
+            fi
+          fi
+          echo "::notice::Checkout: $REPOSITORY does not have the head ref $ref, using base $baseref"
+          echo "ref=$baseref" >> "$GITHUB_OUTPUT"
+        fi
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: ${{ inputs.fetch-depth }}
+        path: ${{ inputs.path }}
+        repository: ${{ inputs.repository }}
+        ref: ${{ steps.repo.outputs.ref }}
+        token: ${{ inputs.token }}

--- a/.github/actions/checkout-head/action.yml
+++ b/.github/actions/checkout-head/action.yml
@@ -40,7 +40,7 @@ runs:
         fi
         
         if git ls-remote --exit-code --heads "https://github.com/$REPOSITORY.git" "$ref"; then
-          echo "::notice::Checkout: using $ref for $REPOSITORY"
+          echo "::notice ::Checkout Head: using $ref for $REPOSITORY"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
         else
           baseref="main"
@@ -49,7 +49,7 @@ runs:
               baseref="$GITHUB_BASE_REF"
             fi
           fi
-          echo "::notice::Checkout: $REPOSITORY does not have the head ref $ref, using base $baseref"
+          echo "::notice ::Checkout Head: $REPOSITORY does not have the head ref $ref, using base $baseref"
           echo "ref=$baseref" >> "$GITHUB_OUTPUT"
         fi
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a new composite action that works like `actions/checkout` but fetches the corresponding head ref if it exists, falling back to base ref as necessary. This removes the need for GH actions to rely on CRT builder for pulling the correct version of a dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
