### PR TITLE
fix: ignore BOM and version-catalog packages

### DIFF
--- a/brazil/transforms.json
+++ b/brazil/transforms.json
@@ -26,9 +26,11 @@
       "aws.smithy.kotlin:smithy-test",
       "aws.smithy.kotlin:testing",
       "aws.smithy.kotlin:bom",
+      "aws.smithy.kotlin:version-catalog",
       "aws.sdk.kotlin:bom",
       "aws.sdk.kotlin.crt:aws-crt-kotlin-android",
-      "aws.sdk.kotlin:testing"
+      "aws.sdk.kotlin:testing",
+      "aws.sdk.kotlin:version-catalog"
     ],
     "rename": {
       "aws.sdk.kotlin.crt:aws-crt-kotlin": "AwsCrtKotlin"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Ignore BOM packages during internal transformation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
