### PR TITLE
fix: allow codegen/codegen-testutils publication and log warning

### DIFF
--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -31,6 +31,8 @@ private val ALLOWED_PUBLICATIONS = listOf(
     "bom",
     "versionCatalog",
     "android", // aws-crt-kotlin
+    "codegen",
+    "codegen-testutils",
 )
 
 /**
@@ -104,7 +106,13 @@ fun Project.configurePublishing(repoName: String) {
     }
 
     tasks.withType<AbstractPublishToMaven>().all {
-        onlyIf { isAvailableForPublication(project, publication) }
+        onlyIf {
+            isAvailableForPublication(project, publication).also {
+                if (!it) {
+                    logger.warn("Skipping publication, project=${project.name}; publication=${publication.name}")
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add `codegen` and `codegen-testutils` to allowed publications list
- Log a warning when skipping publications


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
