### PR TITLE
feat: Add `NATIVE_ENABLED` boolean flag controlled by `aws.kotlin.native` property

### DIFF
--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -105,13 +105,13 @@ fun Project.configureKmpTargets() {
             // FIXME Configure Apple
             // FIXME Configure Windows
 
-            withIf (NATIVE_ENABLED && hasLinux, kmpExt) {
+            withIf(NATIVE_ENABLED && hasLinux, kmpExt) {
                 linuxX64()
                 // FIXME - Okio missing arm64 target support
 //                linuxArm64()
             }
 
-            withIf (NATIVE_ENABLED && hasDesktop, kmpExt) {
+            withIf(NATIVE_ENABLED && hasDesktop, kmpExt) {
                 linuxX64()
                 // FIXME Configure desktop
             }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -96,7 +96,7 @@ fun Project.configureKmpTargets() {
             configureJvm()
         }
 
-        if (NATIVE_ENABLED && hasLinux) {
+        if (hasLinux && !NATIVE_DISABLED) {
             configureLinux()
         }
 
@@ -105,13 +105,13 @@ fun Project.configureKmpTargets() {
             // FIXME Configure Apple
             // FIXME Configure Windows
 
-            withIf(NATIVE_ENABLED && hasLinux, kmpExt) {
+            withIf(hasLinux && !NATIVE_DISABLED, kmpExt) {
                 linuxX64()
                 // FIXME - Okio missing arm64 target support
 //                linuxArm64()
             }
 
-            withIf(NATIVE_ENABLED && hasDesktop, kmpExt) {
+            withIf(hasDesktop && !NATIVE_DISABLED, kmpExt) {
                 linuxX64()
                 // FIXME Configure desktop
             }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -96,7 +96,7 @@ fun Project.configureKmpTargets() {
             configureJvm()
         }
 
-        if (hasLinux && !NATIVE_DISABLED) {
+        if (hasLinux && NATIVE_ENABLED) {
             configureLinux()
         }
 
@@ -105,13 +105,13 @@ fun Project.configureKmpTargets() {
             // FIXME Configure Apple
             // FIXME Configure Windows
 
-            withIf(hasLinux && !NATIVE_DISABLED, kmpExt) {
+            withIf(hasLinux && NATIVE_ENABLED, kmpExt) {
                 linuxX64()
                 // FIXME - Okio missing arm64 target support
 //                linuxArm64()
             }
 
-            withIf(hasDesktop && !NATIVE_DISABLED, kmpExt) {
+            withIf(hasDesktop && NATIVE_ENABLED, kmpExt) {
                 linuxX64()
                 // FIXME Configure desktop
             }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -105,13 +105,13 @@ fun Project.configureKmpTargets() {
             // FIXME Configure Apple
             // FIXME Configure Windows
 
-            if (hasLinux) {
+            withIf (NATIVE_ENABLED && hasLinux, kmpExt) {
                 linuxX64()
                 // FIXME - Okio missing arm64 target support
 //                linuxArm64()
             }
 
-            if (hasDesktop) {
+            withIf (NATIVE_ENABLED && hasDesktop, kmpExt) {
                 linuxX64()
                 // FIXME Configure desktop
             }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -96,7 +96,7 @@ fun Project.configureKmpTargets() {
             configureJvm()
         }
 
-        if (hasLinux) {
+        if (NATIVE_ENABLED && hasLinux) {
             configureLinux()
         }
 

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/IdeUtils.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/IdeUtils.kt
@@ -26,7 +26,7 @@ val HOST_NAME = when {
 
 val Project.COMMON_JVM_ONLY get() = IDEA_ACTIVE && properties["aws.kotlin.ide.jvmAndCommonOnly"] == "true"
 
-val Project.NATIVE_DISABLED get() = properties["aws.kotlin.disableNative"] == "true"
+val Project.NATIVE_ENABLED get() = properties["aws.kotlin.native"]?.let { it == "true" } ?: true
 
 /**
  * Scope down the native target enabled when working in intellij

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/IdeUtils.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/IdeUtils.kt
@@ -26,6 +26,8 @@ val HOST_NAME = when {
 
 val Project.COMMON_JVM_ONLY get() = IDEA_ACTIVE && properties["aws.kotlin.ide.jvmAndCommonOnly"] == "true"
 
+val Project.NATIVE_ENABLED get() = properties["aws.sdk.kotlin.native"] == "true"
+
 /**
  * Scope down the native target enabled when working in intellij
  */

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/IdeUtils.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/IdeUtils.kt
@@ -26,7 +26,7 @@ val HOST_NAME = when {
 
 val Project.COMMON_JVM_ONLY get() = IDEA_ACTIVE && properties["aws.kotlin.ide.jvmAndCommonOnly"] == "true"
 
-val Project.NATIVE_ENABLED get() = properties["aws.sdk.kotlin.native"] == "true"
+val Project.NATIVE_DISABLED get() = properties["aws.kotlin.disableNative"] == "true"
 
 /**
  * Scope down the native target enabled when working in intellij


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for a Gradle property `aws.kotlin.native` to control building native targets such as `linuxx64`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
