### PR TITLE
fix: use all property sources for kmp target enabled properties

### DIFF
--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -92,29 +92,21 @@ fun Project.configureKmpTargets() {
         // enable targets
         configureCommon()
 
-        if (hasJvm) {
+        if (hasJvm && JVM_ENABLED) {
             configureJvm()
         }
 
-        if (hasLinux && NATIVE_ENABLED) {
+        // FIXME Configure JS
+        // FIXME Configure Apple
+        // FIXME Configure Windows
+
+        withIf(hasLinux && NATIVE_ENABLED, kmpExt) {
             configureLinux()
         }
 
-        withIf(!COMMON_JVM_ONLY, kmpExt) {
-            // FIXME Configure JS
-            // FIXME Configure Apple
-            // FIXME Configure Windows
-
-            withIf(hasLinux && NATIVE_ENABLED, kmpExt) {
-                linuxX64()
-                // FIXME - Okio missing arm64 target support
-//                linuxArm64()
-            }
-
-            withIf(hasDesktop && NATIVE_ENABLED, kmpExt) {
-                linuxX64()
-                // FIXME Configure desktop
-            }
+        withIf(hasDesktop && NATIVE_ENABLED, kmpExt) {
+            configureLinux()
+            // FIXME Configure desktop
         }
 
         kmpExt.configureSourceSetsConvention()
@@ -168,6 +160,8 @@ fun Project.configureLinux() {
                 enabled = false
             }
         }
+        // FIXME - Okio missing arm64 target support
+        // linuxArm64()
     }
 }
 

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/IdeUtils.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/IdeUtils.kt
@@ -4,6 +4,7 @@
  */
 package aws.sdk.kotlin.gradle.kmp
 
+import aws.sdk.kotlin.gradle.util.prop
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -24,9 +25,8 @@ val HOST_NAME = when {
     else -> error("Unknown os name `$OS_NAME`")
 }
 
-val Project.COMMON_JVM_ONLY get() = IDEA_ACTIVE && properties["aws.kotlin.ide.jvmAndCommonOnly"] == "true"
-
-val Project.NATIVE_ENABLED get() = properties["aws.kotlin.native"]?.let { it == "true" } ?: true
+val Project.JVM_ENABLED get() = prop("aws.kotlin.jvm")?.let { it == "true" } ?: true
+val Project.NATIVE_ENABLED get() = prop("aws.kotlin.native")?.let { it == "true" } ?: true
 
 /**
  * Scope down the native target enabled when working in intellij


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Remove `aws.kotlin.ide.jvmAndCommonOnly` property as this has weird semantics with individual target enable/disable.
* Add `aws.kotlin.jvm` property for conditional enable/disable of JVM target.
* Pull these properties using our extension function which will look for `local.properties` file in several places (including `~/.sdkdev/local.properties` which allows defining properties in one place that will affect all projects/builds).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
