### PR TITLE
fix: workaround for gradle 8+ dependency issues

### DIFF
--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -12,6 +12,7 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.*
+import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 import java.time.Duration
 
@@ -105,10 +106,16 @@ fun Project.configurePublishing(repoName: String) {
                 )
                 sign(publications)
             }
+
+            // FIXME - workaround for https://github.com/gradle/gradle/issues/26091
+            val signingTasks = tasks.withType<Sign>()
+            tasks.withType<AbstractPublishToMaven>().configureEach {
+                mustRunAfter(signingTasks)
+            }
         }
     }
 
-    tasks.withType<AbstractPublishToMaven>().all {
+    tasks.withType<AbstractPublishToMaven>().configureEach {
         onlyIf {
             isAvailableForPublication(project, publication).also {
                 if (!it) {


### PR DESCRIPTION
*Issue #, if available:*
workaround for https://github.com/gradle/gradle/issues/26091

*Description of changes:*
Workaround for Gradle 8.5 upgrade having issues with task dependencies and signing

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':bom:signVersionCatalogPublication' (type 'Sign').
  - Gradle detected a problem with the following location: '/codebuild/output/src1917448208/src/smithy-kotlin/bom/build/distributions/bom-1.0.5-javadoc.jar.asc'.
    
    Reason: Task ':bom:publishBomPublicationToTestLocalRepository' uses this output of task ':bom:signVersionCatalogPublication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
