### PR TITLE
feat: codegen plugin

### DIFF
--- a/build-plugins/build.gradle.kts
+++ b/build-plugins/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
     // make our custom lint rules available to the buildscript classpath
     runtimeOnly(project(":ktlint-rules"))
     implementation(libs.nexusPublishPlugin)
+    implementation(libs.smithy.model)
+    implementation(libs.smithy.gradle.base.plugin)
+    testImplementation(libs.junit.jupiter)
 }
 
 group = "aws.sdk.kotlin"
@@ -36,6 +39,11 @@ gradlePlugin {
         val awsKotlinRepoToolsPlugin by creating {
             id = "aws.sdk.kotlin.kmp"
             implementationClass = "aws.sdk.kotlin.gradle.kmp.KmpDefaultsPlugin"
+        }
+
+        val awsKotlinSmithyBuildPlugin by creating {
+            id = "aws.sdk.kotlin.gradle.smithybuild"
+            implementationClass = "aws.sdk.kotlin.gradle.codegen.SmithyBuildPlugin"
         }
     }
 }
@@ -50,4 +58,8 @@ tasks.withType<KotlinCompile> {
 tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/build-plugins/build.gradle.kts
+++ b/build-plugins/build.gradle.kts
@@ -6,15 +6,10 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
-
 plugins {
     `kotlin-dsl`
     `java-gradle-plugin`
+    alias(libs.plugins.plugin.publish)
 }
 
 repositories {
@@ -22,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation(gradleApi())
+    // FIXME - should probably be compile only
     implementation(kotlin("gradle-plugin", "1.9.20"))
     // make our custom lint rules available to the buildscript classpath
     runtimeOnly(project(":ktlint-rules"))
@@ -32,18 +27,18 @@ dependencies {
     testImplementation(libs.junit.jupiter)
 }
 
-group = "aws.sdk.kotlin"
-
 gradlePlugin {
     plugins {
         val awsKotlinRepoToolsPlugin by creating {
             id = "aws.sdk.kotlin.kmp"
             implementationClass = "aws.sdk.kotlin.gradle.kmp.KmpDefaultsPlugin"
+            description = "Kotlin Multiplatform defaults and build settings for AWS Kotlin repositories"
         }
 
         val awsKotlinSmithyBuildPlugin by creating {
             id = "aws.sdk.kotlin.gradle.smithybuild"
             implementationClass = "aws.sdk.kotlin.gradle.codegen.SmithyBuildPlugin"
+            description = "A plugin that wraps smithy gradle base plugin and provides a DSL for generating smithy-build.json dynamically"
         }
     }
 }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
@@ -27,9 +27,9 @@ open class SmithyBuildExtension(private val project: Project) {
      */
     public fun getProjectionPath(projectionName: String, pluginName: String): Provider<Path> =
         SmithyUtils.getProjectionOutputDirProperty(project).map {
-            // FIXME - bug in smithy gradle base? it expects the input file to pass "isDirectory"
-            // but that flag is only true IFF the path _exists_ AND is a directory
-            // should probably check if file exists before checking if it's a directory
+            // FIXME - smithy gradle plugin expects the input file to pass "isDirectory"
+            // but that flag is only true IFF the path exists AND is a directory
+            // see https://github.com/smithy-lang/smithy-gradle-plugin/issues/113
             it.asFile.mkdirs()
             SmithyUtils.getProjectionPluginPath(it.asFile, projectionName, pluginName)
         }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
@@ -33,15 +33,6 @@ open class SmithyBuildExtension(private val project: Project) {
             it.asFile.mkdirs()
             SmithyUtils.getProjectionPluginPath(it.asFile, projectionName, pluginName)
         }
-
-    // /**
-    //  * Get the list of all the imports for the projections configured
-    //  */
-    // val models: FileCollection
-    //     get() {
-    //         val paths = projections.flatMap(SmithyProjection::imports)
-    //         return project.files(paths)
-    //     }
 }
 
 // smithy-kotlin specific extensions

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
@@ -27,6 +27,7 @@ open class SmithyBuildExtension(private val project: Project) {
      */
     public fun getProjectionPath(projectionName: String, pluginName: String): Provider<Path> =
         SmithyUtils.getProjectionOutputDirProperty(project).map {
+            println("getProjectionOutputDirProp: $it; isDirectory: ${it.asFile.isDirectory}")
             SmithyUtils.getProjectionPluginPath(it.asFile, projectionName, pluginName)
         }
 

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
@@ -27,7 +27,10 @@ open class SmithyBuildExtension(private val project: Project) {
      */
     public fun getProjectionPath(projectionName: String, pluginName: String): Provider<Path> =
         SmithyUtils.getProjectionOutputDirProperty(project).map {
-            println("getProjectionOutputDirProp: $it; isDirectory: ${it.asFile.isDirectory}")
+            // FIXME - bug in smithy gradle base? it expects the input file to pass "isDirectory"
+            // but that flag is only true IFF the path _exists_ AND is a directory
+            // should probably check if file exists before checking if it's a directory
+            it.asFile.mkdirs()
             SmithyUtils.getProjectionPluginPath(it.asFile, projectionName, pluginName)
         }
 

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen
+
+import aws.sdk.kotlin.gradle.codegen.dsl.SmithyProjection
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import software.amazon.smithy.gradle.SmithyUtils
+import java.nio.file.Path
+
+/**
+ * Register and build Smithy projections
+ */
+open class SmithyBuildExtension(private val project: Project) {
+
+    val projections = project.objects.domainObjectContainer(SmithyProjection::class.java) { name ->
+        SmithyProjection(name)
+    }
+
+    /**
+     * Get the output projection path for the given projection and plugin name
+     *
+     * @param projectionName the name of the projection to get the output path for
+     * @param pluginName the name of the plugin to get the output path for
+     */
+    public fun getProjectionPath(projectionName: String, pluginName: String): Provider<Path> =
+        SmithyUtils.getProjectionOutputDirProperty(project).map {
+            SmithyUtils.getProjectionPluginPath(it.asFile, projectionName, pluginName)
+        }
+
+    // /**
+    //  * Get the list of all the imports for the projections configured
+    //  */
+    // val models: FileCollection
+    //     get() {
+    //         val paths = projections.flatMap(SmithyProjection::imports)
+    //         return project.files(paths)
+    //     }
+}
+
+// smithy-kotlin specific extensions
+
+/**
+ * Get the projection path for the given projection name for the `smithy-kotlin` plugin.
+ * This is equivalent to `smithyBuild.getProjectionPath(projectionName, "kotlin-codegen")
+ *
+ * @param projectionName the name of the projection to use
+ */
+public fun SmithyBuildExtension.smithyKotlinProjectionPath(projectionName: String): Provider<Path> =
+    getProjectionPath(projectionName, "kotlin-codegen")
+
+/**
+ * Get the default generated kotlin source directory for the `smithy-kotlin` plugin.
+ * This is equivalent to `smithyBuild.getProjectionPath(projectionName, "kotlin-codegen")
+ *
+ * @param projectionName the name of the projection to use
+ */
+public fun SmithyBuildExtension.smithyKotlinProjectionSrcDir(projectionName: String): Provider<Path> =
+    smithyKotlinProjectionPath(projectionName).map { it.resolve("src/main/kotlin") }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
@@ -101,7 +101,7 @@ class SmithyBuildPlugin : Plugin<Project> {
             resolvedCliClasspath.set(codegenConfig)
             runtimeClasspath.set(codegenConfig)
             buildClasspath.set(codegenConfig)
-            smithyBuildConfigs.set(generateSmithyBuild.get().outputs.files)
+            smithyBuildConfigs.set(project.files(generateSmithyBuild))
         }
     }
 }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
@@ -55,7 +55,7 @@ const val SMITHY_BUILD_EXTENSION_NAME = "smithyBuild"
  * // register the generated code as a kotlin source directory
  * codegen.projections.all {
  *     kotlin.sourceSets.main {
- *         kotlin.srcDir(smithyBuild.getProjectionPath(projectionName, "kotlin-codegen").map { it.resolve("src/main/kotlin") })
+ *         kotlin.srcDir(smithyBuild.smithyKotlinProjectionSrcDir(projectionName))
  *     }
  * }
  * ```

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
@@ -80,6 +80,9 @@ class SmithyBuildPlugin : Plugin<Project> {
         val generateSmithyBuild = tasks.register<GenerateSmithyBuild>(TASK_GENERATE_SMITHY_BUILD) {
             group = "codegen"
             projections.set(smithyBuildExtension.projections)
+            onlyIf {
+                projections.get().isNotEmpty()
+            }
         }
 
         val codegenConfig = configurations.register("codegen")

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
@@ -8,6 +8,7 @@ import aws.sdk.kotlin.gradle.codegen.dsl.TASK_GENERATE_SMITHY_BUILD
 import aws.sdk.kotlin.gradle.codegen.dsl.TASK_GENERATE_SMITHY_PROJECTIONS
 import aws.sdk.kotlin.gradle.codegen.dsl.smithyBuildExtension
 import aws.sdk.kotlin.gradle.codegen.tasks.GenerateSmithyBuild
+import aws.sdk.kotlin.gradle.codegen.tasks.json
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.register
@@ -79,7 +80,10 @@ class SmithyBuildPlugin : Plugin<Project> {
     private fun Project.registerCodegenTasks() {
         val generateSmithyBuild = tasks.register<GenerateSmithyBuild>(TASK_GENERATE_SMITHY_BUILD) {
             group = "codegen"
-            projections.set(smithyBuildExtension.projections)
+            val configProvider = project.provider {
+                smithyBuildExtension.projections.json
+            }
+            smithyBuildConfig.set(configProvider)
             onlyIf {
                 smithyBuildExtension.projections.isNotEmpty()
             }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen
+
+import aws.sdk.kotlin.gradle.codegen.dsl.TASK_GENERATE_SMITHY_BUILD
+import aws.sdk.kotlin.gradle.codegen.dsl.TASK_GENERATE_SMITHY_PROJECTIONS
+import aws.sdk.kotlin.gradle.codegen.dsl.smithyBuildExtension
+import aws.sdk.kotlin.gradle.codegen.tasks.GenerateSmithyBuild
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.register
+import software.amazon.smithy.gradle.tasks.SmithyBuildTask
+
+const val SMITHY_BUILD_EXTENSION_NAME = "smithyBuild"
+
+/**
+ * This plugin provides the following functionality:
+ * - DSL for programmatically defining a projection
+ * - A configuration to add dependencies used for generating projections
+ * - Task for generating `smithy-build.json`
+ * - Task for generating code using the generated `smithy-build.json`
+ *
+ * It re-uses tasks from the `software.amazon.smithy.gradle.smithy-base` plugin in an opinionated way.
+ *
+ * Example usage:
+ *
+ * ```
+ * plugins {
+ *     id("aws.sdk.kotlin.gradle.smithybuild")
+ * }
+ *
+ * // Configure `smithy-build.json`
+ * smithyBuild {
+ *     projections {
+ *         create("myProjection") { ... }
+ *     }
+ * }
+ *
+ * // Get the codegen config and add the dependencies required for generating the projection(s)
+ * val codegen by configurations.getting
+ * dependencies {
+ *     codegen(project(":codegen:smithy-kotlin-codegen"))
+ *     codegen(libs.smithy.cli)
+ *     codegen(libs.smithy.model)
+ * }
+ *
+ * // use the generated code in the compilation of this project
+ * tasks.withType<KotlinCompile> {
+ *     dependsOn(tasks.generateSmithyProjections)
+ * }
+ *
+ * // register the generated code as a kotlin source directory
+ * codegen.projections.all {
+ *     kotlin.sourceSets.main {
+ *         kotlin.srcDir(smithyBuild.getProjectionPath(projectionName, "kotlin-codegen").map { it.resolve("src/main/kotlin") })
+ *     }
+ * }
+ * ```
+ *
+ * Alternatively if you have a static build config you can override the configuration used when generating projections:
+ *
+ * ```
+ * tasks.generateSmithyProjections {
+ *     smithyBuildConfigs.set(files("path-to-my-smithy-build.json"))
+ * }
+ * ```
+ */
+class SmithyBuildPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = target.run {
+        installExtension()
+        registerCodegenTasks()
+    }
+
+    private fun Project.installExtension() =
+        extensions.create(SMITHY_BUILD_EXTENSION_NAME, SmithyBuildExtension::class.java, project)
+
+    private fun Project.registerCodegenTasks() {
+        val generateSmithyBuild = tasks.register<GenerateSmithyBuild>(TASK_GENERATE_SMITHY_BUILD) {
+            group = "codegen"
+            projections.set(smithyBuildExtension.projections)
+        }
+
+        val codegenConfig = configurations.register("codegen")
+
+        // FIXME - bug in smithy gradle base plugin that requires these configurations to exist
+        // https://github.com/smithy-lang/smithy-gradle-plugin/pull/112
+        listOf(
+            "smithyCli",
+            "smithyBuild",
+            "runtimeClasspath",
+        ).map(configurations::maybeCreate)
+
+        tasks.register<SmithyBuildTask>(TASK_GENERATE_SMITHY_PROJECTIONS) {
+            group = "codegen"
+            dependsOn(generateSmithyBuild)
+            resolvedCliClasspath.set(codegenConfig)
+            runtimeClasspath.set(codegenConfig)
+            buildClasspath.set(codegenConfig)
+            smithyBuildConfigs.set(files(generateSmithyBuild.map { it.smithyBuildConfig.get() }))
+        }
+    }
+}

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
@@ -98,7 +98,7 @@ class SmithyBuildPlugin : Plugin<Project> {
             resolvedCliClasspath.set(codegenConfig)
             runtimeClasspath.set(codegenConfig)
             buildClasspath.set(codegenConfig)
-            smithyBuildConfigs.set(files(generateSmithyBuild.map { it.smithyBuildConfig.get() }))
+            smithyBuildConfigs.set(generateSmithyBuild.get().outputs.files)
         }
     }
 }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
@@ -81,7 +81,7 @@ class SmithyBuildPlugin : Plugin<Project> {
             group = "codegen"
             projections.set(smithyBuildExtension.projections)
             onlyIf {
-                projections.get().isNotEmpty()
+                smithyBuildExtension.projections.isNotEmpty()
             }
         }
 

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/ProjectExtensions.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/ProjectExtensions.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen.dsl
+
+import aws.sdk.kotlin.gradle.codegen.tasks.GenerateSmithyBuild
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.named
+import software.amazon.smithy.gradle.tasks.SmithyBuildTask
+
+internal const val TASK_GENERATE_SMITHY_BUILD = "generateSmithyBuild"
+internal const val TASK_GENERATE_SMITHY_PROJECTIONS = "generateSmithyProjections"
+
+public val TaskContainer.generateSmithyBuild: TaskProvider<GenerateSmithyBuild>
+    get() = named<GenerateSmithyBuild>(TASK_GENERATE_SMITHY_BUILD)
+
+public val TaskContainer.generateSmithyProjections: TaskProvider<SmithyBuildTask>
+    get() = named<SmithyBuildTask>(TASK_GENERATE_SMITHY_PROJECTIONS)

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyBuildPluginSettings.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyBuildPluginSettings.kt
@@ -5,11 +5,12 @@
 package aws.sdk.kotlin.gradle.codegen.dsl
 
 import software.amazon.smithy.model.node.ToNode
+import java.io.Serializable
 
 /**
  * Represents settings related to a Smithy plugin
  */
-interface SmithyBuildPluginSettings : ToNode {
+interface SmithyBuildPluginSettings : ToNode, Serializable {
     /**
      * The name of the build plugin (e.g. `kotlin-codegen`). This is used when generating
      * the projection settings for the plugin

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyBuildPluginSettings.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyBuildPluginSettings.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen.dsl
+
+import software.amazon.smithy.model.node.ToNode
+
+/**
+ * Represents settings related to a Smithy plugin
+ */
+interface SmithyBuildPluginSettings : ToNode {
+    /**
+     * The name of the build plugin (e.g. `kotlin-codegen`). This is used when generating
+     * the projection settings for the plugin
+     */
+    val pluginName: String
+}

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyBuildPluginSettings.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyBuildPluginSettings.kt
@@ -5,12 +5,11 @@
 package aws.sdk.kotlin.gradle.codegen.dsl
 
 import software.amazon.smithy.model.node.ToNode
-import java.io.Serializable
 
 /**
  * Represents settings related to a Smithy plugin
  */
-interface SmithyBuildPluginSettings : ToNode, Serializable {
+interface SmithyBuildPluginSettings : ToNode {
     /**
      * The name of the build plugin (e.g. `kotlin-codegen`). This is used when generating
      * the projection settings for the plugin

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
@@ -8,14 +8,13 @@ import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.model.node.ToNode
-import java.io.Serializable
 import java.util.*
 
 /**
  * Container for `smithy-kotlin` plugin settings
  * See https://github.com/awslabs/smithy-kotlin/blob/main/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
  */
-class SmithyKotlinApiSettings : ToNode, Serializable {
+class SmithyKotlinApiSettings : ToNode {
     var visibility: String? = null
     var nullabilityCheckMode: String? = null
     var defaultValueSerializationMode: String? = null
@@ -56,7 +55,7 @@ class SmithyKotlinApiSettings : ToNode, Serializable {
         "SmithyKotlinApiSettings(visibility=$visibility, nullabilityCheckMode=$nullabilityCheckMode, defaultValueSerializationMode=$defaultValueSerializationMode, enableEndpointAuthProvider=$enableEndpointAuthProvider)"
 }
 
-class SmithyKotlinBuildSettings : ToNode, Serializable {
+class SmithyKotlinBuildSettings : ToNode {
     var generateFullProject: Boolean? = null
     var generateDefaultBuildFiles: Boolean? = null
     var optInAnnotations: List<String>? = null

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
@@ -8,13 +8,14 @@ import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.model.node.ToNode
+import java.io.Serializable
 import java.util.*
 
 /**
  * Container for `smithy-kotlin` plugin settings
  * See https://github.com/awslabs/smithy-kotlin/blob/main/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
  */
-class SmithyKotlinApiSettings : ToNode {
+class SmithyKotlinApiSettings : ToNode, Serializable {
     var visibility: String? = null
     var nullabilityCheckMode: String? = null
     var defaultValueSerializationMode: String? = null
@@ -28,9 +29,34 @@ class SmithyKotlinApiSettings : ToNode {
         builder.withNullableMember("enableEndpointAuthProvider", enableEndpointAuthProvider)
         return builder.build()
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SmithyKotlinApiSettings
+
+        if (visibility != other.visibility) return false
+        if (nullabilityCheckMode != other.nullabilityCheckMode) return false
+        if (defaultValueSerializationMode != other.defaultValueSerializationMode) return false
+        if (enableEndpointAuthProvider != other.enableEndpointAuthProvider) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = visibility?.hashCode() ?: 0
+        result = 31 * result + (nullabilityCheckMode?.hashCode() ?: 0)
+        result = 31 * result + (defaultValueSerializationMode?.hashCode() ?: 0)
+        result = 31 * result + (enableEndpointAuthProvider?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "SmithyKotlinApiSettings(visibility=$visibility, nullabilityCheckMode=$nullabilityCheckMode, defaultValueSerializationMode=$defaultValueSerializationMode, enableEndpointAuthProvider=$enableEndpointAuthProvider)"
 }
 
-class SmithyKotlinBuildSettings : ToNode {
+class SmithyKotlinBuildSettings : ToNode, Serializable {
     var generateFullProject: Boolean? = null
     var generateDefaultBuildFiles: Boolean? = null
     var optInAnnotations: List<String>? = null
@@ -46,6 +72,29 @@ class SmithyKotlinBuildSettings : ToNode {
 
         return builder.build()
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SmithyKotlinBuildSettings
+
+        if (generateFullProject != other.generateFullProject) return false
+        if (generateDefaultBuildFiles != other.generateDefaultBuildFiles) return false
+        if (optInAnnotations != other.optInAnnotations) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = generateFullProject?.hashCode() ?: 0
+        result = 31 * result + (generateDefaultBuildFiles?.hashCode() ?: 0)
+        result = 31 * result + (optInAnnotations?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "SmithyKotlinBuildSettings(generateFullProject=$generateFullProject, generateDefaultBuildFiles=$generateDefaultBuildFiles, optInAnnotations=$optInAnnotations)"
 }
 
 class SmithyKotlinPluginSettings : SmithyBuildPluginSettings {
@@ -81,6 +130,7 @@ class SmithyKotlinPluginSettings : SmithyBuildPluginSettings {
         if (packageDescription != other.packageDescription) return false
         if (sdkId != other.sdkId) return false
         if (buildSettings != other.buildSettings) return false
+        if (apiSettings != other.apiSettings) return false
 
         return true
     }
@@ -92,6 +142,7 @@ class SmithyKotlinPluginSettings : SmithyBuildPluginSettings {
         result = 31 * result + (packageDescription?.hashCode() ?: 0)
         result = 31 * result + (sdkId?.hashCode() ?: 0)
         result = 31 * result + (buildSettings?.hashCode() ?: 0)
+        result = 31 * result + (apiSettings?.hashCode() ?: 0)
         return result
     }
 
@@ -109,6 +160,9 @@ class SmithyKotlinPluginSettings : SmithyBuildPluginSettings {
 
         return obj.build()
     }
+
+    override fun toString(): String =
+        "SmithyKotlinPluginSettings(pluginName='$pluginName', serviceShapeId=$serviceShapeId, packageName=$packageName, packageVersion=$packageVersion, packageDescription=$packageDescription, sdkId=$sdkId, buildSettings=$buildSettings, apiSettings=$apiSettings)"
 }
 
 fun SmithyProjection.smithyKotlinPlugin(configure: SmithyKotlinPluginSettings.() -> Unit) {

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen.dsl
+
+import software.amazon.smithy.model.node.ArrayNode
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.model.node.ToNode
+import java.util.*
+
+/**
+ * Container for `smithy-kotlin` plugin settings
+ * See https://github.com/awslabs/smithy-kotlin/blob/main/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+ */
+class SmithyKotlinApiSettings : ToNode {
+    var visibility: String? = null
+    var nullabilityCheckMode: String? = null
+    var defaultValueSerializationMode: String? = null
+    var enableEndpointAuthProvider: Boolean? = null
+
+    override fun toNode(): Node {
+        val builder = ObjectNode.objectNodeBuilder()
+        builder.withNullableMember("visibility", visibility)
+        builder.withNullableMember("nullabilityCheckMode", nullabilityCheckMode)
+        builder.withNullableMember("defaultValueSerializationMode", defaultValueSerializationMode)
+        builder.withNullableMember("enableEndpointAuthProvider", enableEndpointAuthProvider)
+        return builder.build()
+    }
+}
+
+class SmithyKotlinBuildSettings : ToNode {
+    var generateFullProject: Boolean? = null
+    var generateDefaultBuildFiles: Boolean? = null
+    var optInAnnotations: List<String>? = null
+
+    override fun toNode(): Node {
+        val builder = ObjectNode.objectNodeBuilder()
+
+        builder.withNullableMember("rootProject", generateFullProject)
+        builder.withNullableMember("generateDefaultBuildFiles", generateDefaultBuildFiles)
+
+        val optInArrNode = optInAnnotations?.map { Node.from(it) }?.let { ArrayNode.fromNodes(it) }
+        builder.withOptionalMember("optInAnnotations", Optional.ofNullable(optInArrNode))
+
+        return builder.build()
+    }
+}
+
+class SmithyKotlinPluginSettings : SmithyBuildPluginSettings {
+    override val pluginName: String = "kotlin-codegen"
+
+    var serviceShapeId: String? = null
+    var packageName: String? = null
+    var packageVersion: String? = null
+    var packageDescription: String? = null
+    var sdkId: String? = null
+
+    internal var buildSettings: SmithyKotlinBuildSettings? = null
+    fun buildSettings(configure: SmithyKotlinBuildSettings.() -> Unit) {
+        if (buildSettings == null) buildSettings = SmithyKotlinBuildSettings()
+        buildSettings!!.apply(configure)
+    }
+
+    internal var apiSettings: SmithyKotlinApiSettings? = null
+    fun apiSettings(configure: SmithyKotlinApiSettings.() -> Unit) {
+        if (apiSettings == null) apiSettings = SmithyKotlinApiSettings()
+        apiSettings!!.apply(configure)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SmithyKotlinPluginSettings
+
+        if (serviceShapeId != other.serviceShapeId) return false
+        if (packageName != other.packageName) return false
+        if (packageVersion != other.packageVersion) return false
+        if (packageDescription != other.packageDescription) return false
+        if (sdkId != other.sdkId) return false
+        if (buildSettings != other.buildSettings) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = serviceShapeId?.hashCode() ?: 0
+        result = 31 * result + (packageName?.hashCode() ?: 0)
+        result = 31 * result + (packageVersion?.hashCode() ?: 0)
+        result = 31 * result + (packageDescription?.hashCode() ?: 0)
+        result = 31 * result + (sdkId?.hashCode() ?: 0)
+        result = 31 * result + (buildSettings?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toNode(): Node {
+        val obj = ObjectNode.objectNodeBuilder()
+            .withMember("service", serviceShapeId!!)
+            .withObjectMember("package") {
+                withMember("name", packageName!!)
+                withNullableMember("version", packageVersion)
+                withNullableMember("description", packageDescription)
+            }
+            .withNullableMember("sdkId", sdkId)
+            .withNullableMember("build", buildSettings)
+            .withNullableMember("api", apiSettings)
+
+        return obj.build()
+    }
+}
+
+fun SmithyProjection.smithyKotlinPlugin(configure: SmithyKotlinPluginSettings.() -> Unit) {
+    val p = plugins.computeIfAbsent("kotlin-codegen") { SmithyKotlinPluginSettings() } as SmithyKotlinPluginSettings
+    p.apply(configure)
+}

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyProjection.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyProjection.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.gradle.codegen.dsl
 import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.ObjectNode
-import java.io.Serializable
 
 /**
  * A container for settings related to a single Smithy projection.
@@ -16,8 +15,7 @@ import java.io.Serializable
  *
  * @param name the name of the projection
  */
-class SmithyProjection(val name: String) : Serializable {
-    // NOTE: We implement Serializable because this is used in a task input property and is required by Gradle when used that way
+class SmithyProjection(val name: String) {
 
     /**
      * List of files/directories that contain models that are considered sources models of the build.

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyProjection.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyProjection.kt
@@ -7,6 +7,7 @@ package aws.sdk.kotlin.gradle.codegen.dsl
 import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.ObjectNode
+import java.io.Serializable
 
 /**
  * A container for settings related to a single Smithy projection.
@@ -15,7 +16,11 @@ import software.amazon.smithy.model.node.ObjectNode
  *
  * @param name the name of the projection
  */
-class SmithyProjection(val name: String) {
+class SmithyProjection(val name: String) : Serializable {
+    // NOTE: We implement Serializable because this is used in a task input property and is required by Gradle when used that way
+    companion object {
+        private val serialVersionUID: Long = 1L
+    }
 
     /**
      * List of files/directories that contain models that are considered sources models of the build.
@@ -83,4 +88,22 @@ class SmithyProjection(val name: String) {
         result = 31 * result + plugins.hashCode()
         return result
     }
+
+    // /**
+    //  * Always treat de-serialization as a full-blown constructor, by
+    //  * validating the final state of the de-serialized object.
+    //  */
+    // private fun readObject(inputStream: ObjectInputStream) {
+    //     // always perform the default de-serialization first
+    //     inputStream.defaultReadObject();
+    // }
+    //
+    // /**
+    //  * This is the default implementation of writeObject.
+    //  * Customise if necessary.
+    //  */
+    // private fun writeObject( outputStream: ObjectOutputStream): Unit {
+    //     // perform the default serialization for all non-transient, non-static fields
+    //     outputStream.defaultWriteObject();
+    // }
 }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyProjection.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyProjection.kt
@@ -18,9 +18,6 @@ import java.io.Serializable
  */
 class SmithyProjection(val name: String) : Serializable {
     // NOTE: We implement Serializable because this is used in a task input property and is required by Gradle when used that way
-    companion object {
-        private val serialVersionUID: Long = 1L
-    }
 
     /**
      * List of files/directories that contain models that are considered sources models of the build.
@@ -88,22 +85,4 @@ class SmithyProjection(val name: String) : Serializable {
         result = 31 * result + plugins.hashCode()
         return result
     }
-
-    // /**
-    //  * Always treat de-serialization as a full-blown constructor, by
-    //  * validating the final state of the de-serialized object.
-    //  */
-    // private fun readObject(inputStream: ObjectInputStream) {
-    //     // always perform the default de-serialization first
-    //     inputStream.defaultReadObject();
-    // }
-    //
-    // /**
-    //  * This is the default implementation of writeObject.
-    //  * Customise if necessary.
-    //  */
-    // private fun writeObject( outputStream: ObjectOutputStream): Unit {
-    //     // perform the default serialization for all non-transient, non-static fields
-    //     outputStream.defaultWriteObject();
-    // }
 }

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyProjection.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyProjection.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen.dsl
+
+import software.amazon.smithy.model.node.ArrayNode
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+
+/**
+ * A container for settings related to a single Smithy projection.
+ *
+ * See https://awslabs.github.io/smithy/1.0/guides/building-models/build-config.html#projections
+ *
+ * @param name the name of the projection
+ */
+class SmithyProjection(val name: String) {
+
+    /**
+     * List of files/directories that contain models that are considered sources models of the build.
+     */
+    var sources: List<String> = emptyList()
+
+    /**
+     * List of files/directories to import when building the projection
+     */
+    var imports: List<String> = emptyList()
+
+    /**
+     * A list of transforms to apply
+     *
+     * See https://awslabs.github.io/smithy/1.0/guides/building-models/build-config.html#transforms
+     */
+    var transforms: List<String> = emptyList()
+
+    /**
+     * Plugin name to plugin settings. Plugins should provide an extension function to configure their own plugin settings
+     */
+    val plugins: MutableMap<String, SmithyBuildPluginSettings> = mutableMapOf()
+
+    internal fun toNode(): Node {
+        // escape windows paths for valid json
+        val formattedImports = imports.map { it.replace("\\", "\\\\") }
+        val formattedSources = sources.map { it.replace("\\", "\\\\") }
+
+        val transformNodes = transforms.map { Node.parse(it) }
+        val obj = ObjectNode.objectNodeBuilder()
+            .withArrayMember("sources", formattedSources)
+            .withArrayMember("imports", formattedImports)
+            .withMember("transforms", ArrayNode.fromNodes(transformNodes))
+
+        if (plugins.isNotEmpty()) {
+            obj.withObjectMember("plugins") {
+                plugins.forEach { (pluginName, pluginSettings) ->
+                    withMember(pluginName, pluginSettings.toNode())
+                }
+            }
+        }
+        return obj.build()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SmithyProjection
+
+        if (name != other.name) return false
+        if (sources != other.sources) return false
+        if (imports != other.imports) return false
+        if (transforms != other.transforms) return false
+        if (plugins != other.plugins) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + imports.hashCode()
+        result = 31 * result + sources.hashCode()
+        result = 31 * result + transforms.hashCode()
+        result = 31 * result + plugins.hashCode()
+        return result
+    }
+}

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/Utils.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/Utils.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen.dsl
+
+import aws.sdk.kotlin.gradle.codegen.SMITHY_BUILD_EXTENSION_NAME
+import aws.sdk.kotlin.gradle.codegen.SmithyBuildExtension
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.get
+import software.amazon.smithy.model.node.ArrayNode
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.model.node.ToNode
+import java.util.*
+
+/**
+ * Get the [SmithyBuildExtension] instance configured for the project
+ */
+internal val Project.smithyBuildExtension: SmithyBuildExtension
+    get() = ((this as ExtensionAware).extensions[SMITHY_BUILD_EXTENSION_NAME] as? SmithyBuildExtension) ?: error("CodegenPlugin has not been applied")
+
+internal fun ObjectNode.Builder.withObjectMember(key: String, block: ObjectNode.Builder.() -> Unit): ObjectNode.Builder {
+    val builder = ObjectNode.objectNodeBuilder()
+    builder.apply(block)
+    return withMember(key, builder.build())
+}
+internal fun ObjectNode.Builder.withNullableMember(key: String, member: String?): ObjectNode.Builder = apply {
+    if (member == null) return this
+    return withMember(key, member)
+}
+
+internal fun ObjectNode.Builder.withNullableMember(key: String, member: Boolean?): ObjectNode.Builder = apply {
+    if (member == null) return this
+    return withMember(key, member)
+}
+
+internal fun <T : ToNode> ObjectNode.Builder.withNullableMember(key: String, member: T?): ObjectNode.Builder =
+    withOptionalMember(key, Optional.ofNullable(member))
+
+internal fun ObjectNode.Builder.withArrayMember(key: String, member: List<String>): ObjectNode.Builder = apply {
+    val arrNode = member.map { Node.from(it) }.let { ArrayNode.fromNodes(it) }
+    return withMember(key, arrNode)
+}

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/Utils.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/Utils.kt
@@ -19,7 +19,7 @@ import java.util.*
  * Get the [SmithyBuildExtension] instance configured for the project
  */
 internal val Project.smithyBuildExtension: SmithyBuildExtension
-    get() = ((this as ExtensionAware).extensions[SMITHY_BUILD_EXTENSION_NAME] as? SmithyBuildExtension) ?: error("CodegenPlugin has not been applied")
+    get() = ((this as ExtensionAware).extensions[SMITHY_BUILD_EXTENSION_NAME] as? SmithyBuildExtension) ?: error("SmithyBuildPlugin has not been applied")
 
 internal fun ObjectNode.Builder.withObjectMember(key: String, block: ObjectNode.Builder.() -> Unit): ObjectNode.Builder {
     val builder = ObjectNode.objectNodeBuilder()

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/tasks/GenerateSmithyBuild.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/tasks/GenerateSmithyBuild.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen.tasks
+
+import aws.sdk.kotlin.gradle.codegen.dsl.SmithyProjection
+import aws.sdk.kotlin.gradle.codegen.dsl.withObjectMember
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
+import software.amazon.smithy.model.node.Node
+
+private const val SMITHY_BUILD_CONFIG_FILENAME = "smithy-build.json"
+
+/**
+ * Task that generates `smithy-build.json` from a set of projections
+ */
+abstract class GenerateSmithyBuild : DefaultTask() {
+
+    /**
+     * The list of projections to generate
+     */
+    @get:Input
+    public abstract val projections: ListProperty<SmithyProjection>
+
+    /**
+     * The output directory for the generated `smithy-build.json` configuration file.
+     * Defaults to the project build directory.
+     */
+    @OutputDirectory
+    @Optional
+    public val outputDir: DirectoryProperty = project.layout.buildDirectory
+
+    @get:OutputFile
+    public val smithyBuildConfig: Provider<RegularFile>
+        get() = outputDir.file(SMITHY_BUILD_CONFIG_FILENAME)
+
+    /**
+     * Generate `smithy-build.json`
+     */
+    @TaskAction
+    fun generateSmithyBuild() {
+        val buildConfig = smithyBuildConfig.get().asFile
+        if (buildConfig.exists()) {
+            buildConfig.delete()
+        }
+
+        buildConfig.parentFile.mkdirs()
+        val contents = projections.get().let(::generateSmithyBuild)
+        buildConfig.writeText(contents)
+    }
+}
+
+private fun generateSmithyBuild(projections: Collection<SmithyProjection>): String {
+    val buildConfig = Node.objectNodeBuilder()
+        .withMember("version", "1.0")
+        .withObjectMember("projections") {
+            projections.forEach { projection ->
+                withMember(projection.name, projection.toNode())
+            }
+        }
+        .build()
+
+    return Node.prettyPrintJson(buildConfig)
+}

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/tasks/GenerateSmithyBuild.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/tasks/GenerateSmithyBuild.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.gradle.codegen.tasks
 import aws.sdk.kotlin.gradle.codegen.dsl.SmithyProjection
 import aws.sdk.kotlin.gradle.codegen.dsl.withObjectMember
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
@@ -28,16 +27,12 @@ abstract class GenerateSmithyBuild : DefaultTask() {
     public abstract val projections: ListProperty<SmithyProjection>
 
     /**
-     * The output directory for the generated `smithy-build.json` configuration file.
+     * The generated `smithy-build.json` configuration file.
      * Defaults to the project build directory.
      */
-    @OutputDirectory
-    @Optional
-    public val outputDir: DirectoryProperty = project.layout.buildDirectory
-
     @get:OutputFile
-    public val smithyBuildConfig: Provider<RegularFile>
-        get() = outputDir.file(SMITHY_BUILD_CONFIG_FILENAME)
+    public val smithyBuildConfig: Provider<RegularFile> =
+        project.layout.buildDirectory.file(SMITHY_BUILD_CONFIG_FILENAME)
 
     /**
      * Generate `smithy-build.json`

--- a/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/tasks/GenerateSmithyBuild.kt
+++ b/build-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/tasks/GenerateSmithyBuild.kt
@@ -7,9 +7,8 @@ package aws.sdk.kotlin.gradle.codegen.tasks
 import aws.sdk.kotlin.gradle.codegen.dsl.SmithyProjection
 import aws.sdk.kotlin.gradle.codegen.dsl.withObjectMember
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import software.amazon.smithy.model.node.Node
 
@@ -31,8 +30,13 @@ abstract class GenerateSmithyBuild : DefaultTask() {
      * Defaults to the project build directory.
      */
     @get:OutputFile
-    public val smithyBuildConfig: Provider<RegularFile> =
-        project.layout.buildDirectory.file(SMITHY_BUILD_CONFIG_FILENAME)
+    public abstract val smithyBuildConfig: RegularFileProperty
+
+    init {
+        smithyBuildConfig.convention(
+            project.layout.buildDirectory.file(SMITHY_BUILD_CONFIG_FILENAME),
+        )
+    }
 
     /**
      * Generate `smithy-build.json`

--- a/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
+++ b/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
@@ -6,6 +6,7 @@ package aws.sdk.kotlin.gradle.codegen
 
 import aws.sdk.kotlin.gradle.codegen.dsl.SmithyBuildPluginSettings
 import aws.sdk.kotlin.gradle.codegen.dsl.SmithyProjection
+import aws.sdk.kotlin.gradle.codegen.dsl.smithyKotlinPlugin
 import aws.sdk.kotlin.gradle.codegen.tasks.GenerateSmithyBuild
 import org.gradle.kotlin.dsl.create
 import org.gradle.testfixtures.ProjectBuilder
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.node.Node
+import java.io.*
 
 class GenerateSmithyBuildTaskTest {
     @Test
@@ -69,5 +71,27 @@ class GenerateSmithyBuildTaskTest {
             }
         """.trimIndent()
         assertEquals(expected, contents)
+    }
+
+    @Test
+    fun testSerializability() {
+        val obj = SmithyProjection("foo").apply {
+            smithyKotlinPlugin {
+                sdkId = "mySdkId"
+            }
+        }
+        val file = File.createTempFile("smithy-build-test", "test-serializability")
+        file.deleteOnExit()
+        val fos = FileOutputStream(file)
+        val oos = ObjectOutputStream(fos)
+        oos.writeObject(obj)
+        oos.close()
+
+        val fis = FileInputStream(file)
+        val ois = ObjectInputStream(fis)
+        val reconstituted = ois.readObject() as SmithyProjection
+        ois.close()
+
+        assertEquals(obj, reconstituted)
     }
 }

--- a/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
+++ b/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
@@ -39,6 +39,7 @@ class GenerateSmithyBuildTaskTest {
             SmithyProjection("foo").apply {
                 imports = listOf("i1")
                 sources = listOf("s1")
+                transforms = listOf("""{ "key": "value" }""")
                 plugins["plugin1"] = testPlugin
             },
         )
@@ -60,7 +61,11 @@ class GenerateSmithyBuildTaskTest {
                         "imports": [
                             "i1"
                         ],
-                        "transforms": [],
+                        "transforms": [
+                            {
+                                "key": "value"
+                            }
+                        ],
                         "plugins": {
                             "plugin1": {
                                 "key1": "value1"

--- a/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
+++ b/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen
+
+import aws.sdk.kotlin.gradle.codegen.dsl.SmithyBuildPluginSettings
+import aws.sdk.kotlin.gradle.codegen.dsl.SmithyProjection
+import aws.sdk.kotlin.gradle.codegen.tasks.GenerateSmithyBuild
+import org.gradle.kotlin.dsl.create
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.node.Node
+
+class GenerateSmithyBuildTaskTest {
+    @Test
+    fun testDefaults() {
+        val testProj = ProjectBuilder.builder().build()
+        val task = testProj.tasks.create<GenerateSmithyBuild>("generateSmithyBuild")
+        assertEquals(task.outputDir, testProj.layout.buildDirectory)
+    }
+
+    @Test
+    fun testGeneratedBuild() {
+        val testProj = ProjectBuilder.builder().build()
+        val testPlugin = object : SmithyBuildPluginSettings {
+            override val pluginName: String = "plugin1"
+
+            override fun toNode(): Node = Node.objectNodeBuilder()
+                .withMember("key1", "value1")
+                .build()
+        }
+
+        val smithyProjections = listOf(
+            SmithyProjection("foo").apply {
+                imports = listOf("i1")
+                sources = listOf("s1")
+                plugins["plugin1"] = testPlugin
+            },
+        )
+        val task = testProj.tasks.create<GenerateSmithyBuild>("generateSmithyBuild") {
+            projections.set(smithyProjections)
+        }
+
+        task.generateSmithyBuild()
+        assertTrue(task.smithyBuildConfig.get().asFile.exists())
+        val contents = task.smithyBuildConfig.get().asFile.readText()
+        val expected = """
+            {
+                "version": "1.0",
+                "projections": {
+                    "foo": {
+                        "sources": [
+                            "s1"
+                        ],
+                        "imports": [
+                            "i1"
+                        ],
+                        "transforms": [],
+                        "plugins": {
+                            "plugin1": {
+                                "key1": "value1"
+                            }
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+        assertEquals(expected, contents)
+    }
+}

--- a/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
+++ b/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
@@ -78,6 +78,12 @@ class GenerateSmithyBuildTaskTest {
         val obj = SmithyProjection("foo").apply {
             smithyKotlinPlugin {
                 sdkId = "mySdkId"
+                apiSettings {
+                    visibility = "public"
+                }
+                buildSettings {
+                    generateDefaultBuildFiles = false
+                }
             }
         }
         val file = File.createTempFile("smithy-build-test", "test-serializability")

--- a/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
+++ b/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
@@ -19,7 +19,7 @@ class GenerateSmithyBuildTaskTest {
     fun testDefaults() {
         val testProj = ProjectBuilder.builder().build()
         val task = testProj.tasks.create<GenerateSmithyBuild>("generateSmithyBuild")
-        assertEquals(task.outputDir, testProj.layout.buildDirectory)
+        assertEquals(task.smithyBuildConfig.get().asFile.path, testProj.layout.buildDirectory.file("smithy-build.json").get().asFile.path)
     }
 
     @Test

--- a/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPluginTest.kt
+++ b/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPluginTest.kt
@@ -8,6 +8,7 @@ import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyBuild
 import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyProjections
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -57,5 +58,21 @@ class SmithyBuildPluginTest {
         """.trimIndent()
 
         assertEquals(expected, contents)
+    }
+
+    @Test
+    fun testProjectionPath() {
+        val testProj = ProjectBuilder.builder().build()
+        testProj.apply<SmithyBuildPlugin>()
+        val ext = testProj.extensions.getByType<SmithyBuildExtension>()
+        ext.projections.create("foo")
+        val expected = testProj.layout.buildDirectory.get().asFile.toPath()
+            .resolve("smithyprojections")
+            .resolve("test")
+            .resolve("foo")
+            .resolve("myplugin")
+            .toString()
+        val actual = ext.getProjectionPath("foo", "myplugin").get().toString()
+        assertEquals(expected, actual)
     }
 }

--- a/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPluginTest.kt
+++ b/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPluginTest.kt
@@ -43,7 +43,7 @@ class SmithyBuildPluginTest {
         }
 
         testProj.tasks.generateSmithyBuild.get().generateSmithyBuild()
-        val contents = testProj.tasks.generateSmithyBuild.get().smithyBuildConfig.get().asFile.readText()
+        val contents = testProj.tasks.generateSmithyBuild.get().generatedOutput.get().asFile.readText()
         val expected = """
             {
                 "version": "1.0",

--- a/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPluginTest.kt
+++ b/build-plugins/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPluginTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.gradle.codegen
+
+import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyBuild
+import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyProjections
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class SmithyBuildPluginTest {
+    @Test
+    fun testTaskAndConfigCreation() {
+        val testProj = ProjectBuilder.builder().build()
+        testProj.apply<SmithyBuildPlugin>()
+
+        assertNotNull(testProj.tasks.findByName("generateSmithyBuild"))
+        assertNotNull(testProj.tasks.findByName("generateSmithyProjections"))
+        assertNotNull(testProj.configurations.findByName("codegen"))
+
+        val generateProjectionTaskDeps = testProj
+            .tasks
+            .generateSmithyProjections
+            .get()
+            .taskDependencies
+            .getDependencies(null)
+            .map { it.name }
+
+        assertTrue(generateProjectionTaskDeps.contains("generateSmithyBuild"))
+    }
+
+    @Test
+    fun testDslAndGeneratedBuild() {
+        val testProj = ProjectBuilder.builder().build()
+        testProj.apply<SmithyBuildPlugin>()
+        testProj.extensions.configure<SmithyBuildExtension> {
+            projections.create("foo")
+        }
+
+        testProj.tasks.generateSmithyBuild.get().generateSmithyBuild()
+        val contents = testProj.tasks.generateSmithyBuild.get().smithyBuildConfig.get().asFile.readText()
+        val expected = """
+            {
+                "version": "1.0",
+                "projections": {
+                    "foo": {
+                        "sources": [],
+                        "imports": [],
+                        "transforms": []
+                    }
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, contents)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,24 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-allprojects {
-    group = "aws.sdk.kotlin"
+plugins {
+    `maven-publish`
+}
 
-    repositories {
-        mavenCentral()
+subprojects {
+    // FIXME - do we want this to be the group?
+    group = "aws.sdk.kotlin"
+    // FIXME - set dynamically
+    version = "0.3.2"
+
+    apply(plugin = "maven-publish")
+    publishing {
+        repositories {
+            maven {
+                name = "testLocal"
+                url = rootProject.layout.buildDirectory.dir("m2").get().asFile.toURI()
+            }
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,15 @@
 [versions]
 ktlint = "0.48.1"
+smithy-version = "1.42.0"
+smithy-gradle-plugin-version = "0.9.0"
+junit-version = "5.10.1"
 
 [libraries]
 ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
 ktlint-test = {module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint" }
 nexusPublishPlugin = { module = "io.github.gradle-nexus:publish-plugin", version = "1.3.0" }
+smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy-version" }
+smithy-gradle-base-plugin = { module = "software.amazon.smithy:smithy-base-plugin", version.ref = "smithy-gradle-plugin-version" }
+
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,3 +13,6 @@ smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "
 smithy-gradle-base-plugin = { module = "software.amazon.smithy:smithy-base-plugin", version.ref = "smithy-gradle-plugin-version" }
 
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-version" }
+
+[plugins]
+plugin-publish = { id = "com.gradle.plugin-publish", version = "1.2.1"}

--- a/ktlint-rules/build.gradle.kts
+++ b/ktlint-rules/build.gradle.kts
@@ -5,14 +5,10 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 description = "Lint rules for the AWS SDK for Kotlin"
 
 plugins {
+    `maven-publish`
     kotlin("jvm")
 }
 
@@ -41,4 +37,12 @@ tasks.withType<KotlinCompile> {
 tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("ktlintRules") {
+            from(components["kotlin"])
+        }
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,5 +17,11 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
 include(":build-plugins")
 include(":ktlint-rules")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a new plugin and DSL that wraps the newer smithy gradle base plugin to dynamically define a `smithy-build.json`. This is largely the same as our existing [plugin](https://github.com/awslabs/aws-sdk-kotlin/blob/main/gradle/sdk-plugins/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/CodegenPlugin.kt) with some minor refactoring to do things in a more gradle friendly way and adapt to the new smithy plugin.

There is also some cleanup to our buildscript, ability to publish the plugin locally, etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
