### PR TITLE
fix: verify tag is being built and released

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To cut a new release:
 
 1. Create a new tag, e.g. `git tag x.y.z`
 2. Push the tag up `git push origin x.y.z`
-3. Kick off the release job hosted in the shared tools account (e.g. `publish-aws-kotlin-repo-tools`)
+3. Kick off the release job hosted in the shared tools account (e.g. `publish-aws-kotlin-repo-tools`) specifying the tag as the source version to build.
 
 
 ## Security

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,11 +3,16 @@
 [ -z "$RELEASE_BUCKET" ] && { echo "RELEASE_BUCKET environment variable not set"; exit 1; }
 [ -z "$PUBLISHING_ROLE_ARN" ] && { echo "PUBLISHING_ROLE_ARN environment variable not set"; exit 1; }
 
+VERSION=$(git describe --tags --abbrev=0)
+HEAD_COMMIT=$(git rev-parse HEAD)
+VERSION_COMMIT=$(git rev-parse $VERSION)
 
-if [ -z "$VERSION" ]; then
-    echo "no explicit version set, using latest reachable git tag"
-    VERSION=$(git describe --tags --abbrev=0)
+if [[ "$HEAD_COMMIT" != "$VERSION_COMMIT" ]]; then
+    echo "error must specify a tag to build! expecting $VERSION_COMMIT for tag $VERSION but found HEAD $HEAD_COMMIT"
+    exit 1
 fi
+
+echo "most recent tag: $VERSION (sha=$VERSION_COMMIT)"
 
 SESSION_CREDS=$(aws sts assume-role --role-arn $PUBLISHING_ROLE_ARN --role-session-name publish-aws-kotlin-repo-tools)
 export AWS_ACCESS_KEY_ID=$(echo "${SESSION_CREDS}" | jq -r '.Credentials.AccessKeyId')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add additional sanity check in the release script that we are building a tag and that the HEAD commit matches that tag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
