### PR TITLE
fix: build-support versioning

### DIFF
--- a/build-plugins/build-support/build.gradle.kts
+++ b/build-plugins/build-support/build.gradle.kts
@@ -31,7 +31,6 @@ gradlePlugin {
         create("artifact-size-metrics") {
             id = "artifact-size-metrics"
             implementationClass = "aws.sdk.kotlin.gradle.plugins.artifactmetrics.ArtifactSizeMetricsPlugin"
-            version = 1.0
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The specified version for the `artifact-size-metrics` plugin was overriding the `build-support` version. This PR fixes that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
