### PR TITLE
fix: make custom source sets depend on common

### DIFF
--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -68,12 +68,12 @@ fun Project.configureKmpTargets() {
         // see https://kotlinlang.org/docs/multiplatform-hierarchy.html#see-the-full-hierarchy-template
         kmpExt.applyDefaultHierarchyTemplate {
             if (hasJvmAndNative) {
-//                common {
+                common {
                     group("jvmAndNative") {
                         withJvm()
                         withNative()
                     }
-//                }
+                }
             }
 
             if (hasWindows) {

--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -68,23 +68,30 @@ fun Project.configureKmpTargets() {
         // see https://kotlinlang.org/docs/multiplatform-hierarchy.html#see-the-full-hierarchy-template
         kmpExt.applyDefaultHierarchyTemplate {
             if (hasJvmAndNative) {
-                group("jvmAndNative") {
-                    withJvm()
-                    withNative()
-                }
+//                common {
+                    group("jvmAndNative") {
+                        withJvm()
+                        withNative()
+                    }
+//                }
             }
 
             if (hasWindows) {
-                group("windows") {
-                    withMingw()
+                common {
+                    group("windows") {
+                        withMingw()
+                    }
                 }
+
             }
 
             if (hasDesktop) {
-                group("desktop") {
-                    withLinux()
-                    withMingw()
-                    withMacos()
+                common {
+                    group("desktop") {
+                        withLinux()
+                        withMingw()
+                        withMacos()
+                    }
                 }
             }
         }

--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -82,7 +82,6 @@ fun Project.configureKmpTargets() {
                         withMingw()
                     }
                 }
-
             }
 
             if (hasDesktop) {


### PR DESCRIPTION
Fixes an error in smithy-kotlin:
```
Kotlin Source Set 'jvmAndNativeMain' is included in compilations of Kotlin Targets: 'jvm', 'linuxX64'
but it doesn't depend on 'commonMain'
```
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
