### PR TITLE
docs: rename `awslabs/smithy-kotlin` to `smithy-lang/smithy-kotlin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains shared tooling for AWS Kotlin repositories:
 
 * `awslabs/aws-sdk-kotlin`
-* `awslabs/smithy-kotlin`
+* `smithy-lang/smithy-kotlin`
 * `awslabs/aws-crt-kotlin`
 
 It contains shared custom Gradle plugins and build logic used to build and release those repositories.

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -54,8 +54,9 @@ fun Project.skipPublishing() {
  * Configure publishing for this project. This applies the `maven-publish` and `signing` plugins and configures
  * the publications.
  * @param repoName the repository name (e.g. `smithy-kotlin`, `aws-sdk-kotlin`, etc)
+ * @param githubOrganization the name of the GitHub organization that [repoName] is located in
  */
-fun Project.configurePublishing(repoName: String) {
+fun Project.configurePublishing(repoName: String, githubOrganization: String = "awslabs") {
     val project = this
     apply(plugin = "maven-publish")
 
@@ -76,8 +77,6 @@ fun Project.configurePublishing(repoName: String) {
 
         publications.all {
             if (this !is MavenPublication) return@all
-
-            val githubOrganization = if (repoName.equals("smithy-kotlin", ignoreCase = true)) "smithy-lang" else "awslabs"
 
             project.afterEvaluate {
                 pom {

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -77,11 +77,13 @@ fun Project.configurePublishing(repoName: String) {
         publications.all {
             if (this !is MavenPublication) return@all
 
+            val githubOrganization = if (repoName.equals("smithy-kotlin", ignoreCase = true)) "smithy-lang" else "awslabs"
+
             project.afterEvaluate {
                 pom {
                     name.set(project.name)
                     description.set(project.description)
-                    url.set("https://github.com/awslabs/$repoName")
+                    url.set("https://github.com/$githubOrganization/$repoName")
                     licenses {
                         license {
                             name.set("The Apache License, Version 2.0")
@@ -95,9 +97,9 @@ fun Project.configurePublishing(repoName: String) {
                         }
                     }
                     scm {
-                        connection.set("scm:git:git://github.com/awslabs/$repoName.git")
-                        developerConnection.set("scm:git:ssh://github.com/awslabs/$repoName.git")
-                        url.set("https://github.com/awslabs/$repoName")
+                        connection.set("scm:git:git://github.com/$githubOrganization/$repoName.git")
+                        developerConnection.set("scm:git:ssh://github.com/$githubOrganization/$repoName.git")
+                        url.set("https://github.com/$githubOrganization/$repoName")
                     }
 
                     artifact(javadocJar)

--- a/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
+++ b/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
@@ -12,7 +12,7 @@ import java.util.*
 
 /**
  * Container for `smithy-kotlin` plugin settings
- * See https://github.com/awslabs/smithy-kotlin/blob/main/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+ * See https://github.com/smithy-lang/smithy-kotlin/blob/main/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
  */
 open class SmithyKotlinApiSettings : ToNode {
     var visibility: String? = null


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/awslabs/aws-kotlin-repo-tools/issues/49

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
