### PR TITLE
fix: install aws-cli using `snap`

### DIFF
--- a/.github/actions/setup-kat/action.yml
+++ b/.github/actions/setup-kat/action.yml
@@ -8,8 +8,7 @@ runs:
     - name: Install AWS CLI
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y awscli
+        sudo snap install aws-cli --classic
     - name: Set up kat
       shell: bash
       run: |


### PR DESCRIPTION
*Issue #, if available:*

awscli install via apt-get started failing very recently with an error: `Package 'awscli' has no installation candidate`. Let's migrate to `snap` since that's a recommended approach by the CLI team: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.