### PR TITLE
fix: don't use gradle to change gradle distribution URL

### DIFF
--- a/.github/actions/configure-gradle/action.yml
+++ b/.github/actions/configure-gradle/action.yml
@@ -13,10 +13,11 @@ runs:
       run: |
         cd ${{ inputs.working-directory }}
         
-        gradleVersion=$(grep "distributionUrl" ./gradle/wrapper/gradle-wrapper.properties | sed -n 's|.*gradle-\([0-9.]*\)-bin.zip|\1|p')
+        GRADLE_VERSION=$(grep "distributionUrl" ./gradle/wrapper/gradle-wrapper.properties | sed -n 's|.*gradle-\([0-9.]*\)-bin.zip|\1|p')
+        CUSTOM_URL="https://d2pjps8lqszrgq.cloudfront.net/gradle-$GRADLE_VERSION-bin.zip"
         
-        echo Configuring custom Gradle distribution URL with version: $gradleVersion
-        echo Setting distribution URL to: https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip
+        echo Configuring custom Gradle distribution URL with version: $GRADLE_VERSION
+        echo Setting distribution URL to: $CUSTOM_URL
         
         # Detect OS and set appropriate sed option
         if sed --version 2>/dev/null | grep -q "GNU sed"; then
@@ -27,5 +28,5 @@ runs:
         
         # Replace the line containing "distributionUrl" with the new distributionUrl
         $SED_CMD "/distributionUrl/c\\
-        distributionUrl=https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip\\
+        distributionUrl=$CUSTOM_URL\\
         " ./gradle/wrapper/gradle-wrapper.properties

--- a/.github/actions/configure-gradle/action.yml
+++ b/.github/actions/configure-gradle/action.yml
@@ -12,7 +12,12 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working-directory }}
+        
         gradleVersion=$(grep "distributionUrl" ./gradle/wrapper/gradle-wrapper.properties | sed -n 's|.*gradle-\([0-9.]*\)-bin.zip|\1|p')
+        
         echo Configuring custom Gradle distribution URL with version: $gradleVersion
-        echo gradle wrapper --gradle-distribution-url https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip
-        gradle wrapper --gradle-distribution-url https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip
+        echo Setting distribution URL to: https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip
+        
+        sed -i "/distributionUrl/c\\
+        distributionUrl=https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip\\
+        " ./gradle/wrapper/gradle-wrapper.properties

--- a/.github/actions/configure-gradle/action.yml
+++ b/.github/actions/configure-gradle/action.yml
@@ -19,12 +19,13 @@ runs:
         echo Setting distribution URL to: https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip
         
         # Detect OS and set appropriate sed option
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-        SED_OPTS=(-i '')  # macOS (BSD sed) requires an empty string after -i
+        if sed --version 2>/dev/null | grep -q "GNU sed"; then
+        SED_CMD="sed -i"  # GNU sed (Linux)
         else
-        SED_OPTS=(-i)  # Linux (GNU sed) does not need an empty string
+        SED_CMD="sed -i ''"  # BSD sed (macOS)
         fi
         
-        sed -i "${SED_OPTS[@]}" "/distributionUrl/c\\
+        # Replace the line containing "distributionUrl" with the new distributionUrl
+        $SED_CMD "/distributionUrl/c\\
         distributionUrl=https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip\\
         " ./gradle/wrapper/gradle-wrapper.properties

--- a/.github/actions/configure-gradle/action.yml
+++ b/.github/actions/configure-gradle/action.yml
@@ -18,6 +18,13 @@ runs:
         echo Configuring custom Gradle distribution URL with version: $gradleVersion
         echo Setting distribution URL to: https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip
         
-        sed -i "/distributionUrl/c\\
+        # Detect OS and set appropriate sed option
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+        SED_OPTS=(-i '')  # macOS (BSD sed) requires an empty string after -i
+        else
+        SED_OPTS=(-i)  # Linux (GNU sed) does not need an empty string
+        fi
+        
+        sed -i "${SED_OPTS[@]}" "/distributionUrl/c\\
         distributionUrl=https://d2pjps8lqszrgq.cloudfront.net/gradle-$gradleVersion-bin.zip\\
         " ./gradle/wrapper/gradle-wrapper.properties

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**We were using gradle to change the gradle distribution URL. That's fine and works, but the purpose of changing the URL is to avoid gradle outages. If we use gradle to change the URL, a fresh install of gradle needs to be downloaded first, from the default distribution URL, which would fail if there's an outage.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
