### PR TITLE
fix: use consistent version of ktlint in build-support plugin and ensure that kotlin-compiler-embeddable isn't in buildscript classpaths

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,10 @@
 [*.{kt,kts}]
 ktlint_code_style = intellij_idea
 
+# ktlint line length enforcement
+max_line_length = 120
+ktlint_ignore_back_ticked_identifier = true
+
 # ktlint rules to disable
 ktlint_standard_no-wildcard-imports = disabled
 ktlint_standard_filename = disabled

--- a/build-plugins/build-support/build.gradle.kts
+++ b/build-plugins/build-support/build.gradle.kts
@@ -19,7 +19,10 @@ repositories {
 
 dependencies {
     // make our custom lint rules available to the buildscript classpath
-    runtimeOnly(project(":ktlint-rules"))
+    runtimeOnly(project(":ktlint-rules")) {
+        // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath in consuming modules
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
+    }
     implementation(libs.nexusPublishPlugin)
     compileOnly(gradleApi())
     implementation("aws.sdk.kotlin:s3:1.1.+")
@@ -36,7 +39,26 @@ gradlePlugin {
     }
 }
 
+val generateKtlintVersion by tasks.registering {
+    // generate the version of the runtime to use as a resource.
+    // this keeps us from having to manually change version numbers in multiple places
+    val resourcesDir = layout.buildDirectory.dir("resources/main/aws/sdk/kotlin/gradle/dsl").get()
+
+    val versionCatalog = rootProject.file("gradle/libs.versions.toml")
+    inputs.file(versionCatalog)
+
+    val versionFile = file("$resourcesDir/ktlint-version.txt")
+    outputs.file(versionFile)
+
+    val version = libs.ktlint.cli.ruleset.core.get().version
+    sourceSets.main.get().output.dir(resourcesDir)
+    doLast {
+        versionFile.writeText("$version")
+    }
+}
+
 tasks.withType<KotlinCompile> {
+    dependsOn(generateKtlintVersion)
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -18,14 +18,21 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 fun Project.configureLinting(lintPaths: List<String>) {
     verifyRootProject { "Kotlin SDK lint configuration is expected to be configured on the root project" }
 
+    val ktlintVersion = object {} // Can't use Project.javaClass because that's using the Gradle classloader
+        .javaClass
+        .getResource("ktlint-version.txt")
+        ?.readText()
+        ?: error("Missing ktlint-version.txt")
+
     val ktlint by configurations.creating
 
     dependencies {
-        val ktlintVersion = "1.3.0"
         ktlint("com.pinterest.ktlint:ktlint-cli:$ktlintVersion") {
             attributes {
                 attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
             }
+            // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath in consuming modules
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
         }
     }
 

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -128,7 +128,9 @@ fun Project.configurePublishing(repoName: String, githubOrganization: String = "
         onlyIf {
             isAvailableForPublication(project, publication).also {
                 if (!it) {
-                    logger.warn("Skipping publication, project=${project.name}; publication=${publication.name}; group=${publication.groupId}")
+                    logger.warn(
+                        "Skipping publication, project=${project.name}; publication=${publication.name}; group=${publication.groupId}",
+                    )
                 }
             }
         }

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/plugins/artifactsizemetrics/AnalyzeArtifactSizeMetrics.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/plugins/artifactsizemetrics/AnalyzeArtifactSizeMetrics.kt
@@ -44,7 +44,11 @@ internal abstract class AnalyzeArtifactSizeMetrics : DefaultTask() {
     init {
         metricsFile.convention(project.layout.buildDirectory.file(OUTPUT_PATH + "artifact-size-metrics.csv"))
         analysisFile.convention(project.layout.buildDirectory.file(OUTPUT_PATH + "artifact-analysis.md"))
-        hasSignificantChangeFile.convention(project.layout.buildDirectory.file(OUTPUT_PATH + "has-significant-change.txt"))
+        hasSignificantChangeFile.convention(
+            project.layout.buildDirectory.file(
+                OUTPUT_PATH + "has-significant-change.txt",
+            ),
+        )
     }
 
     private val pluginConfig = project.rootProject.extensions.getByType(ArtifactSizeMetricsPluginConfig::class.java)
@@ -75,7 +79,8 @@ internal abstract class AnalyzeArtifactSizeMetrics : DefaultTask() {
                 },
             ) { latestReleaseMetrics ->
                 file.writeText(
-                    latestReleaseMetrics.body?.decodeToString() ?: throw GradleException("Metrics from latest release are empty"),
+                    latestReleaseMetrics.body?.decodeToString()
+                        ?: throw GradleException("Metrics from latest release are empty"),
                 )
             }
         }
@@ -129,7 +134,8 @@ internal abstract class AnalyzeArtifactSizeMetrics : DefaultTask() {
         var artifactRequiresAttention = false
 
         val ordinary = StringBuilder()
-            .appendLine("<details>") // See: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections
+            // See: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections
+            .appendLine("<details>")
             .appendLine("<summary>Changed in size</summary>")
             .appendLine()
             .append(tableHeader)
@@ -145,9 +151,21 @@ internal abstract class AnalyzeArtifactSizeMetrics : DefaultTask() {
                         append("|")
                         append(metric.key)
                         append("|")
-                        if (metric.value.currentSize == 0L) append("(does not exist)") else append("%,d".format(metric.value.currentSize))
+                        if (metric.value.currentSize ==
+                            0L
+                        ) {
+                            append("(does not exist)")
+                        } else {
+                            append("%,d".format(metric.value.currentSize))
+                        }
                         append("|")
-                        if (metric.value.latestReleaseSize == 0L) append("(does not exist)") else append("%,d".format(metric.value.latestReleaseSize))
+                        if (metric.value.latestReleaseSize ==
+                            0L
+                        ) {
+                            append("(does not exist)")
+                        } else {
+                            append("%,d".format(metric.value.latestReleaseSize))
+                        }
                         append("|")
                         append("%,d".format(metric.value.delta))
                         append("|")
@@ -174,7 +192,8 @@ internal abstract class AnalyzeArtifactSizeMetrics : DefaultTask() {
         if (artifactOrdinaryChange) appendLine(ordinary)
     }
 
-    private fun ArtifactSizeMetric.requiresAttention() = this.percentage > pluginConfig.significantChangeThresholdPercentage || this.percentage.isNaN()
+    private fun ArtifactSizeMetric.requiresAttention() =
+        this.percentage > pluginConfig.significantChangeThresholdPercentage || this.percentage.isNaN()
 
     private data class ArtifactSizeMetric(
         val currentSize: Long,

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/plugins/artifactsizemetrics/ArtifactSizeMetricsPlugin.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/plugins/artifactsizemetrics/ArtifactSizeMetricsPlugin.kt
@@ -31,18 +31,25 @@ class ArtifactSizeMetricsPlugin : Plugin<Project> {
 
         target.registerRootProjectArtifactSizeMetricsTask(tasks)
 
-        target.tasks.register<CollectDelegatedArtifactSizeMetrics>("collectDelegatedArtifactSizeMetrics") { group = TASK_GROUP }
+        target.tasks.register<CollectDelegatedArtifactSizeMetrics>("collectDelegatedArtifactSizeMetrics") {
+            group =
+                TASK_GROUP
+        }
         target.tasks.register<AnalyzeArtifactSizeMetrics>("analyzeArtifactSizeMetrics") { group = TASK_GROUP }
-        target.tasks.register<PutArtifactSizeMetricsInCloudWatch>("putArtifactSizeMetricsInCloudWatch") { group = TASK_GROUP }
+        target.tasks.register<PutArtifactSizeMetricsInCloudWatch>("putArtifactSizeMetricsInCloudWatch") {
+            group =
+                TASK_GROUP
+        }
         target.tasks.register<SaveArtifactSizeMetrics>("saveArtifactSizeMetrics") { group = TASK_GROUP }
     }
 }
 
-private fun Project.subprojectArtifactSizeMetricsTask(): TaskProvider<CollectArtifactSizeMetrics> = tasks.register<CollectArtifactSizeMetrics>("artifactSizeMetrics") {
-    group = TASK_GROUP
-    onlyIf { tasks.findByName("jvmJar") != null }
-    dependsOn(tasks.withType<Jar>())
-}
+private fun Project.subprojectArtifactSizeMetricsTask(): TaskProvider<CollectArtifactSizeMetrics> =
+    tasks.register<CollectArtifactSizeMetrics>("artifactSizeMetrics") {
+        group = TASK_GROUP
+        onlyIf { tasks.findByName("jvmJar") != null }
+        dependsOn(tasks.withType<Jar>())
+    }
 
 private fun Project.registerRootProjectArtifactSizeMetricsTask(
     subProjects: List<TaskProvider<CollectArtifactSizeMetrics>>,

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/plugins/artifactsizemetrics/CollectDelegatedArtifactSizeMetrics.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/plugins/artifactsizemetrics/CollectDelegatedArtifactSizeMetrics.kt
@@ -39,9 +39,13 @@ internal abstract class CollectDelegatedArtifactSizeMetrics : DefaultTask() {
     fun collect() {
         val pullRequestNumber = project.findProperty("pullRequest")?.toString()?.takeIf { it.isNotEmpty() }
         val releaseTag = project.findProperty("release")?.toString()?.takeIf { it.isNotEmpty() }
-        val identifier = pullRequestNumber ?: releaseTag ?: throw AwsSdkGradleException("Please specify a pull request or release number")
+        val identifier =
+            pullRequestNumber ?: releaseTag
+                ?: throw AwsSdkGradleException("Please specify a pull request or release number")
 
-        val artifactSizeMetricsFileKeys = getFileKeys(identifier) ?: throw AwsSdkGradleException("Unable to list objects from artifact size metrics bucket")
+        val artifactSizeMetricsFileKeys =
+            getFileKeys(identifier)
+                ?: throw AwsSdkGradleException("Unable to list objects from artifact size metrics bucket")
         val artifactSizeMetricsFiles = getFiles(artifactSizeMetricsFileKeys)
         val combined = combine(artifactSizeMetricsFiles)
 

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/util/ProjectExt.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/util/ProjectExt.kt
@@ -70,7 +70,9 @@ public inline fun Project.verifyRootProject(lazyMessage: () -> Any) {
  * @return The property as a String
  */
 fun Project.stringPropertyNotNull(property: String): String = findProperty(property)?.toString()?.also {
-    check(it.isNotEmpty()) { "The $property property is set to empty \"-P$property=\" (no value set). Please specify a value." }
+    check(it.isNotEmpty()) {
+        "The $property property is set to empty \"-P$property=\" (no value set). Please specify a value."
+    }
 } ?: throw AwsSdkGradleException("The $property property is not set. Please set a value: \"-P$property=YOUR_VALUE\"")
 
 class AwsSdkGradleException(message: String) : GradleException(message)

--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -60,7 +60,9 @@ fun Project.configureKmpTargets() {
     pluginManager.withPlugin("kotlin-multiplatform") {
         val kmpExt = extensions.findByType(kmpExtensionClass)
         if (kmpExt == null) {
-            logger.info("$name: skipping KMP configuration because multiplatform plugin has not been configured properly")
+            logger.info(
+                "$name: skipping KMP configuration because multiplatform plugin has not been configured properly",
+            )
             return@withPlugin
         }
 

--- a/build-plugins/smithy-build/build.gradle.kts
+++ b/build-plugins/smithy-build/build.gradle.kts
@@ -27,7 +27,8 @@ gradlePlugin {
         val awsKotlinSmithyBuildPlugin by creating {
             id = "aws.sdk.kotlin.gradle.smithybuild"
             implementationClass = "aws.sdk.kotlin.gradle.codegen.SmithyBuildPlugin"
-            description = "A plugin that wraps smithy gradle base plugin and provides a DSL for generating smithy-build.json dynamically"
+            description =
+                "A plugin that wraps smithy gradle base plugin and provides a DSL for generating smithy-build.json dynamically"
         }
     }
 }

--- a/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
+++ b/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildExtension.kt
@@ -25,13 +25,14 @@ open class SmithyBuildExtension(private val project: Project) {
      * @param projectionName the name of the projection to get the output path for
      * @param pluginName the name of the plugin to get the output path for
      */
-    public fun getProjectionPath(projectionName: String, pluginName: String): Provider<Path> = SmithyUtils.getProjectionOutputDirProperty(project).map {
-        // FIXME - smithy gradle plugin expects the input file to pass "isDirectory"
-        // but that flag is only true IFF the path exists AND is a directory
-        // see https://github.com/smithy-lang/smithy-gradle-plugin/issues/113
-        it.asFile.mkdirs()
-        SmithyUtils.getProjectionPluginPath(it.asFile, projectionName, pluginName)
-    }
+    public fun getProjectionPath(projectionName: String, pluginName: String): Provider<Path> =
+        SmithyUtils.getProjectionOutputDirProperty(project).map {
+            // FIXME - smithy gradle plugin expects the input file to pass "isDirectory"
+            // but that flag is only true IFF the path exists AND is a directory
+            // see https://github.com/smithy-lang/smithy-gradle-plugin/issues/113
+            it.asFile.mkdirs()
+            SmithyUtils.getProjectionPluginPath(it.asFile, projectionName, pluginName)
+        }
 }
 
 // smithy-kotlin specific extensions
@@ -42,7 +43,8 @@ open class SmithyBuildExtension(private val project: Project) {
  *
  * @param projectionName the name of the projection to use
  */
-public fun SmithyBuildExtension.smithyKotlinProjectionPath(projectionName: String): Provider<Path> = getProjectionPath(projectionName, "kotlin-codegen")
+public fun SmithyBuildExtension.smithyKotlinProjectionPath(projectionName: String): Provider<Path> =
+    getProjectionPath(projectionName, "kotlin-codegen")
 
 /**
  * Get the default generated kotlin source directory for the `smithy-kotlin` plugin.
@@ -50,4 +52,5 @@ public fun SmithyBuildExtension.smithyKotlinProjectionPath(projectionName: Strin
  *
  * @param projectionName the name of the projection to use
  */
-public fun SmithyBuildExtension.smithyKotlinProjectionSrcDir(projectionName: String): Provider<Path> = smithyKotlinProjectionPath(projectionName).map { it.resolve("src/main/kotlin") }
+public fun SmithyBuildExtension.smithyKotlinProjectionSrcDir(projectionName: String): Provider<Path> =
+    smithyKotlinProjectionPath(projectionName).map { it.resolve("src/main/kotlin") }

--- a/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
+++ b/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPlugin.kt
@@ -74,7 +74,8 @@ class SmithyBuildPlugin : Plugin<Project> {
         registerCodegenTasks()
     }
 
-    private fun Project.installExtension() = extensions.create(SMITHY_BUILD_EXTENSION_NAME, SmithyBuildExtension::class.java, project)
+    private fun Project.installExtension() =
+        extensions.create(SMITHY_BUILD_EXTENSION_NAME, SmithyBuildExtension::class.java, project)
 
     private fun Project.registerCodegenTasks() {
         val generateSmithyBuild = tasks.register<GenerateSmithyBuild>(TASK_GENERATE_SMITHY_BUILD) {

--- a/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
+++ b/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/SmithyKotlinPluginSettings.kt
@@ -51,7 +51,8 @@ open class SmithyKotlinApiSettings : ToNode {
         return result
     }
 
-    override fun toString(): String = "SmithyKotlinApiSettings(visibility=$visibility, nullabilityCheckMode=$nullabilityCheckMode, defaultValueSerializationMode=$defaultValueSerializationMode, enableEndpointAuthProvider=$enableEndpointAuthProvider)"
+    override fun toString(): String =
+        "SmithyKotlinApiSettings(visibility=$visibility, nullabilityCheckMode=$nullabilityCheckMode, defaultValueSerializationMode=$defaultValueSerializationMode, enableEndpointAuthProvider=$enableEndpointAuthProvider)"
 }
 
 open class SmithyKotlinBuildSettings : ToNode {
@@ -91,7 +92,8 @@ open class SmithyKotlinBuildSettings : ToNode {
         return result
     }
 
-    override fun toString(): String = "SmithyKotlinBuildSettings(generateFullProject=$generateFullProject, generateDefaultBuildFiles=$generateDefaultBuildFiles, optInAnnotations=$optInAnnotations)"
+    override fun toString(): String =
+        "SmithyKotlinBuildSettings(generateFullProject=$generateFullProject, generateDefaultBuildFiles=$generateDefaultBuildFiles, optInAnnotations=$optInAnnotations)"
 }
 
 open class SmithyKotlinPluginSettings : SmithyBuildPluginSettings {
@@ -158,7 +160,8 @@ open class SmithyKotlinPluginSettings : SmithyBuildPluginSettings {
         return obj.build()
     }
 
-    override fun toString(): String = "SmithyKotlinPluginSettings(pluginName='$pluginName', serviceShapeId=$serviceShapeId, packageName=$packageName, packageVersion=$packageVersion, packageDescription=$packageDescription, sdkId=$sdkId, buildSettings=$buildSettings, apiSettings=$apiSettings)"
+    override fun toString(): String =
+        "SmithyKotlinPluginSettings(pluginName='$pluginName', serviceShapeId=$serviceShapeId, packageName=$packageName, packageVersion=$packageVersion, packageDescription=$packageDescription, sdkId=$sdkId, buildSettings=$buildSettings, apiSettings=$apiSettings)"
 }
 
 fun SmithyProjection.smithyKotlinPlugin(configure: SmithyKotlinPluginSettings.() -> Unit) {

--- a/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/Utils.kt
+++ b/build-plugins/smithy-build/src/main/kotlin/aws/sdk/kotlin/gradle/codegen/dsl/Utils.kt
@@ -19,9 +19,13 @@ import java.util.*
  * Get the [SmithyBuildExtension] instance configured for the project
  */
 internal val Project.smithyBuildExtension: SmithyBuildExtension
-    get() = ((this as ExtensionAware).extensions[SMITHY_BUILD_EXTENSION_NAME] as? SmithyBuildExtension) ?: error("SmithyBuildPlugin has not been applied")
+    get() = ((this as ExtensionAware).extensions[SMITHY_BUILD_EXTENSION_NAME] as? SmithyBuildExtension)
+        ?: error("SmithyBuildPlugin has not been applied")
 
-internal fun ObjectNode.Builder.withObjectMember(key: String, block: ObjectNode.Builder.() -> Unit): ObjectNode.Builder {
+internal fun ObjectNode.Builder.withObjectMember(
+    key: String,
+    block: ObjectNode.Builder.() -> Unit,
+): ObjectNode.Builder {
     val builder = ObjectNode.objectNodeBuilder()
     builder.apply(block)
     return withMember(key, builder.build())
@@ -36,7 +40,8 @@ internal fun ObjectNode.Builder.withNullableMember(key: String, member: Boolean?
     return withMember(key, member)
 }
 
-internal fun <T : ToNode> ObjectNode.Builder.withNullableMember(key: String, member: T?): ObjectNode.Builder = withOptionalMember(key, Optional.ofNullable(member))
+internal fun <T : ToNode> ObjectNode.Builder.withNullableMember(key: String, member: T?): ObjectNode.Builder =
+    withOptionalMember(key, Optional.ofNullable(member))
 
 internal fun ObjectNode.Builder.withArrayMember(key: String, member: List<String>): ObjectNode.Builder = apply {
     val arrNode = member.map { Node.from(it) }.let { ArrayNode.fromNodes(it) }

--- a/build-plugins/smithy-build/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
+++ b/build-plugins/smithy-build/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/GenerateSmithyBuildTaskTest.kt
@@ -21,7 +21,10 @@ class GenerateSmithyBuildTaskTest {
     fun testDefaults() {
         val testProj = ProjectBuilder.builder().build()
         val task = testProj.tasks.create<GenerateSmithyBuild>("generateSmithyBuild")
-        assertEquals(task.generatedOutput.get().asFile.path, testProj.layout.buildDirectory.file("smithy-build.json").get().asFile.path)
+        assertEquals(
+            task.generatedOutput.get().asFile.path,
+            testProj.layout.buildDirectory.file("smithy-build.json").get().asFile.path,
+        )
     }
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,8 @@ dependencies {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
         }
+        // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
     }
     ktlint(project(":ktlint-rules"))
 }


### PR DESCRIPTION
## Issue #, if available:

(none)

## Description of changes:

Two major changes:

### Kotlin Gradle Plugin errors

After upgrading to Kotlin 2.1.0, we started seeing Kotlin Gradle Plugin errors in our builds:

```
w: The artifact `org.jetbrains.kotlin:kotlin-compiler-embeddable` is present in the build classpath along Kotlin Gradle plugin.
This may lead to unpredictable and inconsistent behavior.
For more details, see: https://kotl.in/gradle/internal-compiler-symbols
```

This is being caused by our **ktlint** rules and plugin automatically bundling the compiler into its dependencies. This change removes **kotlin-compiler-embeddable** from several places where it was leaking into the buildscript classpath.

### Unify **ktlint** versions

Previously, we hardcoded an outdated version of **ktlint** into our `Project.configureLinting` method. This change uses a build-time version file to keep the version in sync with **libs.versions.toml**.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
