### PR TITLE
chore: fix emit-metrics integration with kat

### DIFF
--- a/.github/actions/emit-metrics/action.yml
+++ b/.github/actions/emit-metrics/action.yml
@@ -42,7 +42,7 @@ runs:
   steps:
     - name: Verify kat exists
       shell: bash
-      run: which kat || ( echo "Cannot find kat installation. Did you forget to run setup-kat first?" && exit 1 )
+      run: kat version || ( echo "Cannot find kat in PATH ($PATH). Did you forget to run setup-kat first?" && exit 1 )
     - name: Emit Metrics
       shell: bash
       run: |

--- a/.github/actions/setup-kat/action.yml
+++ b/.github/actions/setup-kat/action.yml
@@ -18,14 +18,15 @@ runs:
           echo "No versions of kat were found"
           exit 1
         fi
-        echo "Downloading kat version $kat_version"
+        echo "Downloading kat version $kat_version to $PWD"
         
-        aws s3 cp s3://kotlin-sdk-build-tools/kat-releases/$kat_version/kat-$kat_version.zip ./kat.zip
+        aws s3 cp s3://kotlin-sdk-build-tools/kat-releases/$kat_version/kat-$kat_version.zip ./kat.zip --no-progress
         
         echo "Unzipping kat tool"
         unzip -qq ./kat.zip -d kat
         
         kat_binary_path="$PWD/kat/kat-$kat_version/bin"
+        echo "Appending \"$kat_binary_path\" to path"
         export PATH="$kat_binary_path:$PATH"
         echo "$kat_binary_path" >> $GITHUB_PATH
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
@@ -38,7 +38,7 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Previously, the **emit-metrics** action attempted to verify **kat** was installed by executing `which kat` but, unfortunately, `which` is not installed on GH action runners by default and installing it is unnecessary overhead. Thus, replaced that check with a simple `kat version` which will achieve the same outcome without relying on `which`.

Also updated the **setup-kat** action to emit more information about paths (should assist in future debugging) and to silence the AWS CLI progress meter (which is less useful in headless environments anyway).

Also upgraded our invocations of `actions/cache@v2` to `v4` since [`v2` is now EOL](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
