### PR TITLE
chore: install the kat tool in a dedicated home directory instead of using $PWD

### DIFF
--- a/.github/actions/setup-kat/action.yml
+++ b/.github/actions/setup-kat/action.yml
@@ -18,14 +18,20 @@ runs:
           echo "No versions of kat were found"
           exit 1
         fi
-        echo "Downloading kat version $kat_version to $PWD"
-        
+
+        kat_dir="$HOME/kat"
+
+        echo "Creating directory for kat tool at $kat_dir"
+        mkdir -p "$kat_dir"
+        pushd "$kat_dir"
+
+        echo "Downloading kat version $kat_version to $kat_dir"
         aws s3 cp s3://kotlin-sdk-build-tools/kat-releases/$kat_version/kat-$kat_version.zip ./kat.zip --no-progress
         
         echo "Unzipping kat tool"
-        unzip -qq ./kat.zip -d kat
+        unzip -qq ./kat.zip
         
-        kat_binary_path="$PWD/kat/kat-$kat_version/bin"
+        kat_binary_path="$kat_dir/kat-$kat_version/bin"
         echo "Appending \"$kat_binary_path\" to path"
         export PATH="$kat_binary_path:$PATH"
         echo "$kat_binary_path" >> $GITHUB_PATH

--- a/.github/actions/setup-kat/action.yml
+++ b/.github/actions/setup-kat/action.yml
@@ -23,7 +23,7 @@ runs:
 
         echo "Creating directory for kat tool at $kat_dir"
         mkdir -p "$kat_dir"
-        pushd "$kat_dir"
+        cd "$kat_dir"
 
         echo "Downloading kat version $kat_version to $kat_dir"
         aws s3 cp s3://kotlin-sdk-build-tools/kat-releases/$kat_version/kat-$kat_version.zip ./kat.zip --no-progress


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Previously, **kat** was installed in `$PWD` which tends to be the path into which repos will be cloned, causing the existing contents to be deleted. To improve resilience and allow **kat** to be installed _before_ source code is checked out, this PR changes the **kat** install dir to `$HOME/kat`. The unzipped binary path is still added to `$PATH`/`$GITHUB_PATH` as before so existing workflows _should_ be unaffected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
