### PR TITLE
fix: merge main action fetch with depth 0

### DIFF
--- a/.github/actions/merge-main/action.yml
+++ b/.github/actions/merge-main/action.yml
@@ -9,6 +9,8 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Git
       shell: bash

--- a/.github/scripts/merge-main.sh
+++ b/.github/scripts/merge-main.sh
@@ -69,7 +69,7 @@ function merge_main() {
     echo "...switching to branch: $branch"
     git switch "$branch"
     echo "...merging main"
-    git merge -m "misc: merge from main" main
+    git merge -m "misc: merge from main" origin/main
     if [ $? -eq 0 ]; then
       echo "...pushing to origin"
       git push origin "$branch"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Not using `fetch-depth: 0` when calling `actions/checkout@v4` was causing issues while merging:
`fatal refusing to merge unrelated histories`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
