### PR TITLE
fix: stop including embedded compiler in ktlint tasks

### DIFF
--- a/build-plugins/build-support/build.gradle.kts
+++ b/build-plugins/build-support/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 dependencies {
     // make our custom lint rules available to the buildscript classpath
     runtimeOnly(project(":ktlint-rules")) {
-        // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath in consuming modules
+        // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
     }
 
@@ -40,7 +40,26 @@ gradlePlugin {
     }
 }
 
+val generateKtlintVersion by tasks.registering {
+    // generate the version of the runtime to use as a resource.
+    // this keeps us from having to manually change version numbers in multiple places
+    val resourcesDir = layout.buildDirectory.dir("resources/main/aws/sdk/kotlin/gradle/dsl").get()
+
+    val versionCatalog = rootProject.file("gradle/libs.versions.toml")
+    inputs.file(versionCatalog)
+
+    val versionFile = file("$resourcesDir/ktlint-version.txt")
+    outputs.file(versionFile)
+
+    val version = libs.ktlint.cli.ruleset.core.get().version
+    sourceSets.main.get().output.dir(resourcesDir)
+    doLast {
+        versionFile.writeText("$version")
+    }
+}
+
 tasks.withType<KotlinCompile> {
+    dependsOn(generateKtlintVersion)
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")

--- a/build-plugins/build-support/build.gradle.kts
+++ b/build-plugins/build-support/build.gradle.kts
@@ -19,7 +19,11 @@ repositories {
 
 dependencies {
     // make our custom lint rules available to the buildscript classpath
-    runtimeOnly(project(":ktlint-rules"))
+    runtimeOnly(project(":ktlint-rules")) {
+        // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath in consuming modules
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
+    }
+
     implementation(libs.nexusPublishPlugin)
     compileOnly(gradleApi())
     implementation("aws.sdk.kotlin:s3:1.1.+")

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -26,6 +26,9 @@ fun Project.configureLinting(lintPaths: List<String>) {
             attributes {
                 attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
             }
+
+            // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath in consuming modules
+            exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
         }
     }
 

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/CodeStyle.kt
@@ -18,21 +18,23 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 fun Project.configureLinting(lintPaths: List<String>) {
     verifyRootProject { "Kotlin SDK lint configuration is expected to be configured on the root project" }
 
+    val ktlintVersion = object {} // Can't use Project.javaClass because that's using the Gradle classloader
+        .javaClass
+        .getResource("ktlint-version.txt")
+        ?.readText()
+        ?: error("Missing ktlint-version.txt")
+
     val ktlint by configurations.creating
 
     dependencies {
-        val ktlintVersion = "1.3.0"
         ktlint("com.pinterest.ktlint:ktlint-cli:$ktlintVersion") {
             attributes {
-                attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+                attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
             }
-
-            // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath in consuming modules
-            exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
         }
     }
 
-    // add the buildscript classpath which should pickup our custom ktlint-rules (via runtimeOnly dep on this plugin)
+    // add the buildscript classpath which should pick up our custom ktlint-rules (via runtimeOnly dep on this plugin)
     // plus any custom rules added by consumer
     val execKtlintClasspath = ktlint + buildscript.configurations.getByName("classpath")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,11 @@ dependencies {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
         }
+
+        // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
     }
+
     ktlint(project(":ktlint-rules"))
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,11 +49,8 @@ val ktlint by configurations.creating
 dependencies {
     ktlint(libs.ktlint.cli) {
         attributes {
-            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
         }
-
-        // Ensure that kotlin-compiler-embeddable isn't included in the buildscript classpath
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
     }
 
     ktlint(project(":ktlint-rules"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ktlint = "1.5.0"
+ktlint = "1.3.0"
 smithy-version = "1.53.0"
 smithy-gradle-plugin-version = "1.1.0"
 junit-version = "5.10.1"


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Slimmed down version of #70 that focuses strictly on eliminating this compiler warning:

```
w: The artifact `org.jetbrains.kotlin:kotlin-compiler-embeddable` is present in the build classpath along Kotlin Gradle plugin.
This may lead to unpredictable and inconsistent behavior.
For more details, see: https://kotl.in/gradle/internal-compiler-symbols
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.