### PR TITLE
kn: make `Project.prop(name: String)` use `providers.gradleProperty` instead of `properties`

### DIFF
--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/util/ProjectExt.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/util/ProjectExt.kt
@@ -45,7 +45,7 @@ public fun Project.localProperties(): Map<String, Any> {
  * * property from extras
  * @return property if it exists or null
  */
-public fun Project.prop(name: String): Any? = properties[name] ?: localProperties()[name] ?: extra.getOrNull(name)
+public fun Project.prop(name: String): Any? = providers.gradleProperty(name).orNull ?: localProperties()[name] ?: extra.getOrNull(name)
 
 inline fun <reified T> Project.typedProp(name: String): T? {
     val any = prop(name)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`properties` does not detect Gradle properties set by a parent project that's using the current project as a composite build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
