### PR TITLE
fix: use CI user PAT to bypass branch protections

### DIFF
--- a/.github/actions/merge-main/action.yml
+++ b/.github/actions/merge-main/action.yml
@@ -3,6 +3,8 @@ description: Merges main into feature branches (*-main)
 inputs:
   exempt-branches:
     description: Feature branches that are exempt from receiving merges from main (comma separated, no blank space)
+  ci-user-pat:
+    description: The CI user's personal access token to write to the repo
 
 runs:
   using: composite
@@ -11,6 +13,7 @@ runs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        token: ${{ inputs.ci-user-pat }}
 
     - name: Set up Git
       shell: bash

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  pull_request:
 
 jobs:
   merge:
@@ -11,4 +12,5 @@ jobs:
       - name: Merge main
         uses: awslabs/aws-kotlin-repo-tools/.github/actions/merge-main@main
         with:
+          ci-user-pat: ${{ secrets.CI_USER_PAT }}
           exempt-branches: # Add any if required

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-  pull_request:
 
 jobs:
   merge:


### PR DESCRIPTION
*Issue #, if available:*
SDK-KT-610

*Description of changes:*
Need to assume the CI role to bypass branch protection rules

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
