### PR TITLE
chore: revert "feat: upgrade to Kotlin 2.2.0 (#96)"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@
  */
 plugins {
     `maven-publish`
-    alias(libs.plugins.kotlin.jvm) apply false
 }
 
 val releaseVersion = findProperty("release.version") as? String

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 kotlin.code.style=official
+
+# kotlin
+kotlinVersion=2.1.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-kotlin-version = "2.2.0"
 ktlint = "1.3.0"
 smithy-version = "1.60.2"
 smithy-gradle-plugin-version = "1.3.0"
@@ -17,5 +16,4 @@ smithy-gradle-base-plugin = { module = "software.amazon.smithy.gradle:smithy-bas
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-version" }
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-version" }
 plugin-publish = { id = "com.gradle.plugin-publish", version = "1.3.1"}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,12 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+
+    val kotlinVersion: String by settings
+    // configure default plugin versions
+    plugins {
+        id("org.jetbrains.kotlin.jvm") version kotlinVersion
+    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This reverts commit bdb40dcc24b522ab498a118739c264f3160cbc3d.

*Issue #, if available:*

*Description of changes:*

Revert Kotlin 2.2.0 upgrade so we can release Smithy upgrade and Maven publishing changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
