### PR TITLE
chore: pin SDK client versions to avoid non-deterministic build failures

### DIFF
--- a/build-plugins/build-support/build.gradle.kts
+++ b/build-plugins/build-support/build.gradle.kts
@@ -26,8 +26,8 @@ dependencies {
 
     implementation(libs.nexusPublishPlugin)
     compileOnly(gradleApi())
-    implementation("aws.sdk.kotlin:s3:1.4.+")
-    implementation("aws.sdk.kotlin:cloudwatch:1.4.+")
+    implementation(libs.aws.sdk.s3)
+    implementation(libs.aws.sdk.cloudwatch)
     testImplementation(libs.junit.jupiter)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,23 @@
 [versions]
+aws-sdk-version = "1.4.116"
 ktlint = "1.3.0"
+nexus-plugin-version = "2.0.0"
+publish-plugin-version = "1.3.1"
 smithy-version = "1.60.2"
 smithy-gradle-plugin-version = "1.3.0"
 junit-version = "5.10.1"
 
 [libraries]
+aws-sdk-cloudwatch = { module = "aws.sdk.kotlin:cloudwatch", version.ref = "aws-sdk-version" }
+aws-sdk-s3 = { module = "aws.sdk.kotlin:s3", version.ref = "aws-sdk-version" }
 ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint" }
-ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlint" }
 ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlint" }
 ktlint-test = {module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint" }
-nexusPublishPlugin = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
+nexusPublishPlugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-plugin-version" }
 smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy-version" }
 smithy-gradle-base-plugin = { module = "software.amazon.smithy.gradle:smithy-base", version.ref = "smithy-gradle-plugin-version" }
 
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-version" }
 
 [plugins]
-plugin-publish = { id = "com.gradle.plugin-publish", version = "1.3.1"}
+plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "publish-plugin-version"}


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

This change pins the SDK version to a specific revision to avoid issues when a new release is _partially published_ on Maven Central.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
