### PR TITLE
misc: increase jreleaser deployment delay

### DIFF
--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -209,6 +209,8 @@ fun Project.configureJReleaser() {
                                 verifyPom = false // jreleaser doesn't understand toml packaging
                             }
                         }
+                        maxRetries = 100
+                        retryDelay = 60 // seconds
                     }
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Smithy lang has had timeout issues with Jreleaser in the past and this is their config:
https://github.com/smithy-lang/smithy/blob/main/build.gradle.kts#L87-L88

The default retryDelay is 20 seconds and it's been increased to 60 now. Max retries defaults to 100 but now it's explicitly stated. See:
https://jreleaser.org/guide/latest/reference/deploy/maven/maven-central.html#_configuration


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
