### PR TITLE
misc: add back nexus publish plugin support

### DIFF
--- a/build-plugins/build-support/build.gradle.kts
+++ b/build-plugins/build-support/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     }
 
     implementation(libs.jReleaserPlugin)
+    implementation(libs.nexusPublishPlugin)
     compileOnly(gradleApi())
     implementation(libs.aws.sdk.s3)
     implementation(libs.aws.sdk.cloudwatch)

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -73,7 +73,7 @@ fun Project.skipPublishing() {
 fun Project.configurePublishing(
     repoName: String,
     githubOrganization: String = "awslabs",
-    useNexusPublishPlugin: Boolean = false, // TODO:
+    useNexusPublishPlugin: Boolean = true,
 ) {
     val project = this
     apply(plugin = "maven-publish")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ aws-sdk-version = "1.4.116"
 kotlin-version = "2.2.0"
 ktlint = "1.3.0"
 jreleaser-plugin-version = "1.18.0"
+nexus-plugin-version = "2.0.0"
 publish-plugin-version = "1.3.1"
 smithy-version = "1.60.2"
 smithy-gradle-plugin-version = "1.3.0"
@@ -15,6 +16,7 @@ ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint
 ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlint" }
 ktlint-test = {module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint" }
 jReleaserPlugin = { module = "org.jreleaser:jreleaser-gradle-plugin", version.ref = "jreleaser-plugin-version" }
+nexusPublishPlugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-plugin-version" }
 smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy-version" }
 smithy-gradle-base-plugin = { module = "software.amazon.smithy.gradle:smithy-base", version.ref = "smithy-gradle-plugin-version" }
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
We are currently using both jreleaser and nexus publish plugin for our release infrastructure but we are doing so by using different versions of repo tools that contain either nexus publish plugin or jreleaser. This works but if we need to make changes to repo tools, the SDK would not be able to consume them because it's stuck in an older version that has the nexus publish plugin.

Related to: https://github.com/awslabs/aws-kotlin-repo-tools/pull/102

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
