### PR TITLE
feat: add support for specifying the working directory in the artifact-size-metrics action

### DIFF
--- a/.github/actions/artifact-size-metrics/show-results/action.yml
+++ b/.github/actions/artifact-size-metrics/show-results/action.yml
@@ -1,6 +1,10 @@
 name: Artifact Size Metrics - Show Results
 description: Posts a new artifact analysis comment on the PR
-
+inputs:
+  working-directory:
+    required: false
+    description: The working directory to use for reading the previously-generated report.
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -8,6 +12,11 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
+          const workingDirectory = '${{ inputs.working-directory }}'
+          if (workingDirectory) {
+            process.chdir(workingDirectory)
+          }
+
           const fs = require('node:fs')
           const prNumber = context.issue.number ?? process.env.SDK_PR
 


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

This change adds a new optional `working-directory` parameter to the **artifact-size-metrics** action so that it can be correctly run in environments where multiple repos are checked out in various subdirectories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
