### PR TITLE
fix: add back `configureNexus` function

### DIFF
--- a/build-plugins/build-support/build.gradle.kts
+++ b/build-plugins/build-support/build.gradle.kts
@@ -24,7 +24,8 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-compiler-embeddable")
     }
 
-    implementation(libs.jReleaserPlugin)
+    implementation(libs.nexus.publish.plugin)
+    implementation(libs.jreleaser.plugin)
     compileOnly(gradleApi())
     implementation(libs.aws.sdk.s3)
     implementation(libs.aws.sdk.cloudwatch)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,11 @@ if (releaseVersion == null) logger.warn("no release version set")
 val s3Url = propertyOrEnv("release.s3.url", "RELEASE_S3_URL")
 if (s3Url == null) logger.warn("S3 repository not configured, missing S3 url")
 
+allprojects {
+    // Enables running `./gradlew allDeps` to get a comprehensive list of dependencies for every subproject
+    tasks.register<DependencyReportTask>("allDeps") { }
+}
+
 subprojects {
     group = "aws.sdk.kotlin.gradle"
     version = releaseVersion ?: "0.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 aws-sdk-version = "1.4.116"
 kotlin-version = "2.2.0"
 ktlint = "1.3.0"
+nexus-plugin-version = "2.0.0"
 jreleaser-plugin-version = "1.18.0"
 publish-plugin-version = "1.3.1"
 smithy-version = "1.60.2"
@@ -14,7 +15,8 @@ aws-sdk-s3 = { module = "aws.sdk.kotlin:s3", version.ref = "aws-sdk-version" }
 ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint" }
 ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlint" }
 ktlint-test = {module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint" }
-jReleaserPlugin = { module = "org.jreleaser:jreleaser-gradle-plugin", version.ref = "jreleaser-plugin-version" }
+nexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-plugin-version" }
+jreleaser-plugin = { module = "org.jreleaser:jreleaser-gradle-plugin", version.ref = "jreleaser-plugin-version" }
 smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy-version" }
 smithy-gradle-base-plugin = { module = "software.amazon.smithy.gradle:smithy-base", version.ref = "smithy-gradle-plugin-version" }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
finishing the revert that was started in https://github.com/awslabs/aws-sdk-kotlin/pull/1656 by adding back `configureNexus`. This will allow us to upgrade to the latest version of aws-kotlin-repo-tools again. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
