### PR TITLE
misc: temporarily disable aws-crt-kotlin K/N publishing

### DIFF
--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -68,7 +68,7 @@ internal val KOTLIN_NATIVE_PUBLICATION_NAMES = setOf(
 
 // TODO Refactor to support project names _or_ publication group names.
 // aws-crt-kotlin is not published with a group name, so we need to check project names instead.
-private val KOTLIN_NATIVE_PROJECT_NAMES = setOf(
+private val KOTLIN_NATIVE_PROJECT_NAMES = setOf<String>(
     // "aws-crt-kotlin", // TODO Re-enable when ready to publish aws-crt-kotlin Kotlin/Native artifacts
 )
 

--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/dsl/Publish.kt
@@ -69,7 +69,7 @@ internal val KOTLIN_NATIVE_PUBLICATION_NAMES = setOf(
 // TODO Refactor to support project names _or_ publication group names.
 // aws-crt-kotlin is not published with a group name, so we need to check project names instead.
 private val KOTLIN_NATIVE_PROJECT_NAMES = setOf(
-    "aws-crt-kotlin",
+    // "aws-crt-kotlin", // TODO Re-enable when ready to publish aws-crt-kotlin Kotlin/Native artifacts
 )
 
 /**

--- a/build-plugins/build-support/src/test/kotlin/aws/sdk/kotlin/gradle/dsl/PublishTest.kt
+++ b/build-plugins/build-support/src/test/kotlin/aws/sdk/kotlin/gradle/dsl/PublishTest.kt
@@ -38,7 +38,7 @@ class PublishTest {
                     version = "1.2.3"
                     artifactId = "aws-crt-kotlin"
                 }
-                assertTrue(isAvailableForPublication(project, nativeRuntimePublication))
+                assertFalse(isAvailableForPublication(project, nativeRuntimePublication))
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Disable aws-crt-kotlin K/N publishing until kn-main is merged back into main. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
