### PR TITLE
fix: add hasJvmAndNative as an additional enabler of hasNative

### DIFF
--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -31,7 +31,7 @@ val Project.hasCommon: Boolean get() = files.any {
 
 // always configured with common
 val Project.hasJvm: Boolean get() = hasCommon || hasJvmAndNative || files.any { it.name == "jvm" }
-val Project.hasNative: Boolean get() = hasCommon || files.any { it.name == "native" }
+val Project.hasNative: Boolean get() = hasCommon || hasJvmAndNative || files.any { it.name == "native" }
 val Project.hasJs: Boolean get() = hasCommon || files.any { it.name == "js" }
 val Project.hasJvmAndNative: Boolean get() = hasCommon || files.any { it.name == "jvmAndNative" }
 


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

This change updates the target configuration logic for multiplatform source sets. Specifically, the `hasNative` flag previously did not resolve to `true` if a project had no **common** or **native** sources. For instance, **smithy-kotlin/kn-main:runtime:auth
:aws-signing-crt** only has a **jvmAndNative** source set but resolves `hasNative = false`. This change fixes that issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
