### PR TITLE
fix: disable configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,2 @@
 kotlin.code.style=official
 
-# TODO Remove once configuration cache is enabled by default
-org.gradle.configuration-cache=true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Disable configuration cache to fix an issue encountered while releasing v0.4.39
```
FAILURE: Build failed with an exception.
--
 
* What went wrong:
Execution failed for task ':ktlint-rules:compileKotlin'.
> Error while evaluating property 'disableMultiModuleIC' of task ':ktlint-rules:compileKotlin'.
> Invocation of 'Task.project' by task ':ktlint-rules:compileKotlin' at execution time is unsupported with the configuration cache.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
