### PR TITLE
misc: fix target configuration for non-KN projects

### DIFF
--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -121,7 +121,6 @@ fun Project.configureKmpTargets() {
                 } else {
                     println("Skipping configuration of Windows target for unsupported project: $group")
                 }
-
             }
             if ((hasLinux || hasDesktop) && HostManager.hostIsLinux) {
                 if (group == "aws.sdk.kotlin.crt") { // TODO Remove special-casing once K/N is released across the entire project

--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -109,10 +109,19 @@ fun Project.configureKmpTargets() {
 
         if (NATIVE_ENABLED) {
             if ((hasApple || hasDesktop) && HostManager.hostIsMac) {
-                kmpExt.apply { configureApple() }
+                if (group == "aws.sdk.kotlin.crt") {
+                    kmpExt.apply { configureApple() }
+                } else {
+                    println("Skipping configuration of Apple targets for unsupported project: $group")
+                }
             }
             if ((hasWindows || hasDesktop) && HostManager.hostIsMingw) {
-                kmpExt.apply { configureWindows() }
+                if (group == "aws.sdk.kotlin.crt") {
+                    kmpExt.apply { configureWindows() }
+                } else {
+                    println("Skipping configuration of Windows target for unsupported project: $group")
+                }
+
             }
             if ((hasLinux || hasDesktop) && HostManager.hostIsLinux) {
                 if (group == "aws.sdk.kotlin.crt") { // TODO Remove special-casing once K/N is released across the entire project


### PR DESCRIPTION
*Issue #, if available:*
smithy-kotlin/main builds are failing on macOS because we're configuring Apple targets that don't have implementations

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
