### PR TITLE
chore: add a `posix` source set for code which must run on Linux and Apple (POSIX-compliant) but not on MinGW/Windows (not POSIX-compliant)

### DIFF
--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -42,12 +42,13 @@ val Project.hasDesktop: Boolean get() = hasNative || files.any { it.name == "des
 val Project.hasLinux: Boolean get() = hasNative || hasJvmAndNative || files.any { it.name == "linux" }
 val Project.hasApple: Boolean get() = hasNative || hasJvmAndNative || files.any { it.name == "apple" }
 val Project.hasWindows: Boolean get() = hasNative || files.any { it.name == "windows" }
+val Project.hasPosix: Boolean get() = hasNative || hasJvmAndNative || files.any { it.name == "posix" }
 
 /**
  * Test if a project follows the convention and needs configured for KMP (used in handful of spots where we have a
  * subproject that is just a container for other projects but isn't a KMP project itself).
  */
-val Project.needsKmpConfigured: Boolean get() = hasCommon || hasJvm || hasNative || hasJs || hasJvmAndNative || hasDesktop || hasLinux || hasApple || hasWindows
+val Project.needsKmpConfigured: Boolean get() = hasCommon || hasJvm || hasNative || hasJs || hasJvmAndNative || hasDesktop || hasLinux || hasApple || hasWindows || hasPosix
 
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
 fun Project.configureKmpTargets() {
@@ -92,6 +93,16 @@ fun Project.configureKmpTargets() {
                     group("desktop") {
                         withLinux()
                         withMingw()
+                        withMacos()
+                    }
+                }
+            }
+
+            if (hasPosix) {
+                common {
+                    group("posix") {
+                        // Linux and Apple but NOT Mingw/Windows
+                        withLinux()
                         withMacos()
                     }
                 }


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

This change adds a new native source set called `posix` which includes our Linux and Apple targets since those environments are POSIX-compliant. Excluded is Windows/MinGW which are _not_ POSIX-compliant. This will enable us to reuse code which makes use of Kotlin's `platform.posix` declarations without duplicating across Linux and Apple source sets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
