### PR TITLE
chore: restructure source sets to be hierarchically correct

### DIFF
--- a/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
+++ b/build-plugins/kmp-conventions/src/main/kotlin/aws/sdk/kotlin/gradle/kmp/ConfigureTargets.kt
@@ -82,28 +82,34 @@ fun Project.configureKmpTargets() {
 
             if (hasWindows) {
                 common {
-                    group("windows") {
-                        withMingw()
+                    group("native") {
+                        group("windows") {
+                            withMingw()
+                        }
                     }
                 }
             }
 
             if (hasDesktop) {
                 common {
-                    group("desktop") {
-                        withLinux()
-                        withMingw()
-                        withMacos()
+                    group("native") {
+                        group("desktop") {
+                            withLinux()
+                            withMingw()
+                            withMacos()
+                        }
                     }
                 }
             }
 
             if (hasPosix) {
                 common {
-                    group("posix") {
-                        // Linux and Apple but NOT Mingw/Windows
-                        withLinux()
-                        withMacos()
+                    group("native") {
+                        group("posix") {
+                            // Linux and Apple but NOT Mingw/Windows
+                            withLinux()
+                            withApple()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

This change restructures our specialized Native source sets to properly depend on the main Native source set. In other words, the`posix`, `desktop`, and `windows` source sets now depend on the `native` source set. This is useful for being able to locate `actual` declarations which may be in non-leaf source sets.

For example, if the `native` source set has an `expect` declaration, the corresponding `actual` can now be found in `posix` _in addition to_ in `linuxX64`, `macosArm64`, etc.

This change also updates the `posix` source set to include all Apple targets (e.g., iOS), not just MacOS targets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
