### PR TITLE
misc: cross platform setup kat

### DIFF
--- a/.github/actions/setup-kat/action.yml
+++ b/.github/actions/setup-kat/action.yml
@@ -5,19 +5,19 @@ description: >
 runs:
   using: composite
   steps:
-    - name: Install AWS CLI (ubuntu)
-      if: matrix.os == 'ubuntu-latest' || !matrix.os
+    - name: Install AWS CLI (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo snap install aws-cli --classic
     - name: Install AWS CLI (macOS)
-      if: matrix.os == 'macos-latest'
+      if: runner.os == 'macOS'
       shell: bash
       run: |
         curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
         sudo installer -pkg AWSCLIV2.pkg -target /
     - name: Install AWS CLI (Windows)
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
       shell: powershell
       run: |
         Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -OutFile "AWSCLIV2.msi"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add cross-platform AWS CLI installation to setup-kat action
Test in https://github.com/aws/aws-kotlin-repo-tools/pull/142

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
