### PR TITLE
Replace JUnit with kotlin-test

### DIFF
--- a/build-plugins/build-support/build.gradle.kts
+++ b/build-plugins/build-support/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)
     implementation(libs.proguard)
 }

--- a/build-plugins/kmp-conventions/build.gradle.kts
+++ b/build-plugins/kmp-conventions/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     implementation(project(":build-plugins:build-support"))
     compileOnly(kotlin("gradle-plugin", "2.1.0"))
-    testImplementation(libs.junit.jupiter)
+    testImplementation(kotlin("test"))
 }
 
 gradlePlugin {

--- a/build-plugins/kmp-conventions/build.gradle.kts
+++ b/build-plugins/kmp-conventions/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     implementation(project(":build-plugins:build-support"))
     compileOnly(kotlin("gradle-plugin", "2.1.0"))
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
 }
 
 gradlePlugin {

--- a/build-plugins/smithy-build/build.gradle.kts
+++ b/build-plugins/smithy-build/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     implementation(libs.smithy.model)
     implementation(libs.smithy.gradle.base.plugin)
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlin.test)
 }
 
 gradlePlugin {

--- a/build-plugins/smithy-build/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPluginTest.kt
+++ b/build-plugins/smithy-build/src/test/kotlin/aws/sdk/kotlin/gradle/codegen/SmithyBuildPluginTest.kt
@@ -10,8 +10,10 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class SmithyBuildPluginTest {
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ ktlint-version = "1.8.0"
 publish-plugin-version = "2.1.1"
 smithy-version = "1.68.0"
 smithy-gradle-plugin-version = "1.4.0"
-junit-version = "6.0.3"
 coroutines-version = "1.10.2"
 slf4j-version = "2.0.17"
 okhttp-version = "5.3.2"
@@ -17,7 +16,6 @@ ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-co
 ktlint-rule-engine = { module = "com.pinterest.ktlint:ktlint-rule-engine", version.ref = "ktlint-version" }
 smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy-version" }
 smithy-gradle-base-plugin = { module = "software.amazon.smithy.gradle:smithy-base", version.ref = "smithy-gradle-plugin-version" }
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-version" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-version" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-version" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j-version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j-version
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp-version" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-version" }
 proguard = { module = "com.guardsquare:proguard-gradle", version.ref = "proguard-version" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin-version" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-version" }
 
 [plugins]

--- a/ktlint/minor-version-rules/build.gradle.kts
+++ b/ktlint/minor-version-rules/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
 
         test {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(libs.kotlin.test)
             }
         }
     }

--- a/ktlint/style-rules/build.gradle.kts
+++ b/ktlint/style-rules/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
         }
         test {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(libs.kotlin.test)
                 implementation(libs.ktlint.rule.engine)
                 implementation(libs.slf4j.simple) // Required by ktlint rule engine tests
             }


### PR DESCRIPTION

Replace remaining JUnit usages with kotlin-test for consistency across our Kotlin repositories.

### Changes
- Replaced org.junit.jupiter.api imports with kotlin.test in SmithyBuildPluginTest.kt
- Replaced testImplementation(libs.junit.jupiter) with testImplementation(kotlin("test")) in kmp-conventions/build.gradle.kts
- Removed junit-version and junit-jupiter entries from gradle/libs.versions.toml

### What's kept and why
- useJUnitPlatform() in test task configs — required by kotlin-test-junit5 as the underlying test runner engine
- kotlin("test-junit5") in ConfigureTargets.kt — this is the kotlin-test JVM adapter for downstream KMP projects, not a direct JUnit dependency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
