### PR TITLE
fix: correct dependencies of Dokka tasks to include KSP source sets

### DIFF
--- a/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/hll/KspConfig.kt
+++ b/build-plugins/build-support/src/main/kotlin/aws/sdk/kotlin/gradle/hll/KspConfig.kt
@@ -37,7 +37,7 @@ fun Project.configureKspCodegen(kspProjects: List<String>) {
     }
 
     // Move the generated KSP source from jvm to common
-    tasks.register("moveGenSrc") {
+    val moveGenSrc = tasks.register("moveGenSrc") {
         // Can't move source until it's generated
         dependsOn(tasks.named("kspKotlinJvm"))
 
@@ -63,10 +63,16 @@ fun Project.configureKspCodegen(kspProjects: List<String>) {
 
     // Ensure all source jar tasks depend on the generated source move
     tasks.matching { it.name.endsWith("SourcesJar", ignoreCase = true) || it.name == "jvmProcessResources" }.configureEach {
-        dependsOn("moveGenSrc")
+        dependsOn(moveGenSrc)
     }
+
+    // Ensure all Dokka tasks depend on the generated source move
+    tasks.matching { it.name.startsWith("dokka", ignoreCase = true) }.configureEach {
+        dependsOn(moveGenSrc)
+    }
+
     tasks.withType(KotlinCompilationTask::class.java) {
-        dependsOn("moveGenSrc")
+        dependsOn(moveGenSrc)
     }
 
     // Finally, wire up the generated source to the commonMain source set


### PR DESCRIPTION
*Description of changes:*

Updates Dokka tasks to properly depend on the `moveGenSrc` task used in KSP modules. This ensures that Gradle correctly sequences the tasks and avoids errors like the following:

```
Some problems were found with the configuration of task ':hll:ddb-mapper:dynamodb-mapper:moveGenSrc' (type 'DefaultTask').
  - Gradle detected a problem with the following location: '/workplace/issmith/aws-sdk/aws-sdk-kotlin/hll/ddb-mapper/dynamodb-mapper/build/generated/ksp/jvm/jvmMain'.
    
    Reason: Task ':hll:ddb-mapper:dynamodb-mapper:dokkaGenerateModuleHtml' uses this output of task ':hll:ddb-mapper:dynamodb-mapper:moveGenSrc' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':hll:ddb-mapper:dynamodb-mapper:moveGenSrc' as an input of ':hll:ddb-mapper:dynamodb-mapper:dokkaGenerateModuleHtml'.
      2. Declare an explicit dependency on ':hll:ddb-mapper:dynamodb-mapper:moveGenSrc' from ':hll:ddb-mapper:dynamodb-mapper:dokkaGenerateModuleHtml' using Task#dependsOn.
      3. Declare an explicit dependency on ':hll:ddb-mapper:dynamodb-mapper:moveGenSrc' from ':hll:ddb-mapper:dynamodb-mapper:dokkaGenerateModuleHtml' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/9.2.1/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
