### PR TITLE
remove snap and use command installer

### DIFF
--- a/.github/actions/setup-kat/action.yml
+++ b/.github/actions/setup-kat/action.yml
@@ -9,7 +9,9 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        sudo snap install aws-cli --classic
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip -qq awscliv2.zip
+        sudo ./aws/install
     - name: Install AWS CLI (macOS)
       if: runner.os == 'macOS'
       shell: bash

--- a/.github/actions/setup-kat/action.yml
+++ b/.github/actions/setup-kat/action.yml
@@ -12,6 +12,7 @@ runs:
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
         unzip -qq awscliv2.zip
         sudo ./aws/install
+        rm -rf awscliv2.zip aws
     - name: Install AWS CLI (macOS)
       if: runner.os == 'macOS'
       shell: bash
@@ -24,6 +25,7 @@ runs:
       run: |
         Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -OutFile "AWSCLIV2.msi"
         Start-Process msiexec.exe -Wait -ArgumentList '/I AWSCLIV2.msi /quiet'
+        Remove-Item -Force AWSCLIV2.msi
     - name: Set up kat
       shell: bash
       run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove snap command which is currently down and use command installer directly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
