### PR TITLE
remove usage of push in merge main

### DIFF
--- a/.github/actions/merge-main/action.yml
+++ b/.github/actions/merge-main/action.yml
@@ -88,25 +88,24 @@ runs:
           local merge_branch=$2
 
           # Open PR if one doesn't already exist
-          local pr_number
-          pr_number=$(gh pr list --head "$merge_branch" --base "$base_branch" --state open --label auto-merge --json number --jq '.[0].number')
+          local pr_ref
+          pr_ref=$(gh pr list --head "$merge_branch" --base "$base_branch" --state open --label auto-merge --json number --jq '.[0].number')
 
-          if [ -z "$pr_number" ]; then
+          if [ -z "$pr_ref" ]; then
             echo "...opening PR from $merge_branch into $base_branch"
-            pr_number=$(gh pr create \
+            pr_ref=$(gh pr create \
               --base "$base_branch" \
               --head "$merge_branch" \
               --title "misc: merge main into $base_branch" \
               --label auto-merge \
-              --body "Automated merge of main into \`$base_branch\`. If there are conflicts, please resolve manually." \
-              | grep -oE '[0-9]+$')
+              --body "Automated merge of main into \`$base_branch\`. If there are conflicts, please resolve manually.")
           else
-            echo "...PR #$pr_number already exists"
+            echo "...PR #$pr_ref already exists"
           fi
 
           # Enable auto-merge (fails gracefully if conflicts exist)
-          echo "...enabling auto-merge on PR #$pr_number"
-          gh pr merge "$pr_number" --merge --delete-branch --auto || echo "...auto-merge could not be enabled (likely conflicts), skipping"
+          echo "...enabling auto-merge on $pr_ref"
+          gh pr merge "$pr_ref" --merge --delete-branch --auto || echo "...auto-merge could not be enabled (likely conflicts), skipping"
         }
 
         function merge_main() {

--- a/.github/actions/merge-main/action.yml
+++ b/.github/actions/merge-main/action.yml
@@ -83,34 +83,30 @@ runs:
 
         filter_feature_branches
 
-        function open_merge_pr() {
+        function open_pr_and_merge() {
           local base_branch=$1
           local merge_branch=$2
 
-          # Check if there's already an auto-merge PR into this branch
+          # Open PR if one doesn't already exist
           local pr_number
           pr_number=$(gh pr list --head "$merge_branch" --base "$base_branch" --state open --label auto-merge --json number --jq '.[0].number')
 
-          if [ -n "$pr_number" ]; then
-            echo "...open PR #$pr_number already exists, checking if mergeable"
-            local mergeable
-            mergeable=$(gh pr view "$pr_number" --json mergeable --jq '.mergeable')
-
-            if [ "$mergeable" == "MERGEABLE" ]; then
-              echo "...PR is mergeable, merging"
-              gh pr merge "$pr_number" --merge --delete-branch
-            else
-              echo "...PR still has conflicts, skipping"
-            fi
-          else
+          if [ -z "$pr_number" ]; then
             echo "...opening PR from $merge_branch into $base_branch"
-            gh pr create \
+            pr_number=$(gh pr create \
               --base "$base_branch" \
               --head "$merge_branch" \
               --title "misc: merge main into $base_branch" \
               --label auto-merge \
-              --body "Automated merge of main into \`$base_branch\` failed due to conflicts. Please resolve manually."
+              --body "Automated merge of main into \`$base_branch\`. If there are conflicts, please resolve manually." \
+              | grep -oE '[0-9]+$')
+          else
+            echo "...PR #$pr_number already exists"
           fi
+
+          # Enable auto-merge (fails gracefully if conflicts exist)
+          echo "...enabling auto-merge on PR #$pr_number"
+          gh pr merge "$pr_number" --merge --delete-branch --auto || echo "...auto-merge could not be enabled (likely conflicts), skipping"
         }
 
         function merge_main() {
@@ -135,7 +131,7 @@ runs:
             fi
 
             git push -u --force-with-lease origin "$merge_branch"
-            open_merge_pr "$branch" "$merge_branch"
+            open_pr_and_merge "$branch" "$merge_branch"
           done
         }
 

--- a/.github/actions/merge-main/action.yml
+++ b/.github/actions/merge-main/action.yml
@@ -122,26 +122,20 @@ runs:
           fi
 
           for branch in "${branches[@]}"; do
-            echo "...switching to branch: $branch"
-            git switch "$branch"
-            echo "...merging main"
-            if git merge -m "misc: merge from main" origin/main; then
-              echo "...pushing to origin"
-              git push origin "$branch"
+            echo "...processing branch: $branch"
+            local merge_branch="main-into-$branch-merge"
+
+            if git rev-parse --verify "refs/remotes/origin/$merge_branch" &>/dev/null; then
+              echo "...merge branch $merge_branch already exists, updating"
+              git switch "$merge_branch"
+              git reset --hard origin/main
             else
-              echo "...merge failed, creating merge branch for manual resolution"
-              git merge --abort
-              local merge_branch="main-into-$branch-merge"
-              if git rev-parse --verify "refs/remotes/origin/$merge_branch" &>/dev/null; then
-                echo "...merge branch $merge_branch already exists, updating"
-                git switch "$merge_branch"
-                git reset --hard origin/main
-              else
-                git switch -c "$merge_branch" origin/main
-              fi
-              git push -u --force-with-lease origin "$merge_branch"
-              open_merge_pr "$branch" "$merge_branch"
+              echo "...creating merge branch $merge_branch"
+              git switch -c "$merge_branch" origin/main
             fi
+
+            git push -u --force-with-lease origin "$merge_branch"
+            open_merge_pr "$branch" "$merge_branch"
           done
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For branch that prevent push, directly `git merge` + `git push` does not working. The changes open PR in all cases and merge if no conflict, otherwise PR is opened for manual resolution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
