### PR TITLE
add no-changelog label for PR

### DIFF
--- a/.github/actions/merge-main/action.yml
+++ b/.github/actions/merge-main/action.yml
@@ -98,6 +98,7 @@ runs:
               --head "$merge_branch" \
               --title "misc: merge main into $base_branch" \
               --label auto-merge \
+              --label no-changelog \
               --body "Automated merge of main into \`$base_branch\`. If there are conflicts, please resolve manually.")
           else
             echo "...PR #$pr_ref already exists"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add no-changelog label when opening new PR, otherwise no PR will be merged due to lack of changelog

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
