### PR TITLE
fix: ((0++)) raise error as it is post-increment

### DIFF
--- a/.github/workflows/run-release.yml
+++ b/.github/workflows/run-release.yml
@@ -50,7 +50,7 @@ jobs:
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
           PATCH_NUMBER=${PATCH%%[^0-9]*}
           PATCH_SUFFIX=${PATCH#$PATCH_NUMBER}
-          ((PATCH_NUMBER++))
+          PATCH_NUMBER=$((PATCH_NUMBER + 1))
           echo "NEW_VERSION=$MAJOR.$MINOR.$PATCH_NUMBER$PATCH_SUFFIX" >> "$GITHUB_OUTPUT"
 
       - name: Create new version tag


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix release workflow failure when patch version is 0 due to `((0++))` returning exit code 1 under `bash -e`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
